### PR TITLE
Stop app crashing when worklaod user not found

### DIFF
--- a/app/services/domain/display-table.js
+++ b/app/services/domain/display-table.js
@@ -2,13 +2,6 @@ class DisplayTable {
   constructor (headings, rows) {
     this.headings = headings
     this.rows = rows
-    this.isValid()
-  }
-
-  isValid () {
-    if (this.headings.length < 1) {
-      throw new Error('No headings found')
-    }
   }
 }
 


### PR DESCRIPTION
Currently, when the workload user is undefined, the application crashes because
the `DisplayTable` object is validating it has more than one header.

For now, the expected behaviour should be displaying an empty graph the users
with default headings.

In the future we'll want to handle this with a 404 response before the
`get-capacity-table` function is called.