### PR TITLE
336: Add last 16 weeks fields to test helpers

### DIFF
--- a/test/helpers/data/workload-capacity-helper.js
+++ b/test/helpers/data/workload-capacity-helper.js
@@ -44,7 +44,9 @@ module.exports.addWorkloadCapacitiesForOffenderManager = function () {
         sdr_due_next_30_days: 0,
         sdr_conversions_last_30_days: 0,
         paroms_completed_last_30_days: 0,
-        paroms_due_next_30_days: 0
+        paroms_due_next_30_days: 0,
+        license_last_16_weeks: 9,
+        community_last_16_weeks: 10
       })
     })
     .then(function (ids) {


### PR DESCRIPTION
The integration tests were failing due to a schema update in the worker.