### PR TITLE
334: Call getSubNav from the route instead of the service

### DIFF
--- a/app/routes/capacity-route.js
+++ b/app/routes/capacity-route.js
@@ -1,6 +1,6 @@
 const getCapacityView = require('../services/get-capacity-view')
 const dateRangeHelper = require('../services/helpers/date-range-helper')
-const _ = require('lodash')
+const getSubNav = require('../services/get-sub-nav')
 
 module.exports = function (router) {
   router.get(`/:organisationLevel/:id/caseload-capacity`, function (req, res, next) {
@@ -11,12 +11,10 @@ module.exports = function (router) {
     var capacityViewPromise = getCapacityView(id, capacityDateRange, organisationLevel)
 
     return capacityViewPromise.then(function (result) {
-      var activeIndex = _.findIndex(result.subNav, {link: req.path})
-      result.subNav[activeIndex].active = true
       return res.render('capacity', {
         title: result.title,
         subTitle: result.subTitle,
-        subnav: result.subNav,
+        subnav: getSubNav(id, organisationLevel, req.path),
         breadcrumbs: result.breadcrumbs,
         capacity: result.capacityTable
       })

--- a/app/services/domain/link.js
+++ b/app/services/domain/link.js
@@ -1,7 +1,8 @@
 class Link {
-  constructor (title, link) {
+  constructor (title, link, active) {
     this.title = title
     this.link = link
+    this.active = active
   }
 }
 

--- a/app/services/get-capacity-view.js
+++ b/app/services/get-capacity-view.js
@@ -1,5 +1,4 @@
 const getBreadcrumbs = require('./get-breadcrumbs')
-const getSubNav = require('./get-sub-nav')
 const getIndividualWorkloadReports = require('./data/get-individual-workload-reports')
 const getWorkloadReports = require('./data/get-workload-report-views')
 const routeType = require('../constants/organisation-unit')
@@ -18,7 +17,6 @@ module.exports = function (id, capacityDateRange, organisationLevel) {
   }
 
   result.breadcrumbs = getBreadcrumbs(id, organisationLevel)
-  result.subNav = getSubNav(id, organisationLevel)
 
   return workloadReportsPromise.then(function (results) {
     result.capacityTable = tableCreator.createCapacityTable(id, organisationalUnitType, capacityDateRange, results)

--- a/app/services/get-sub-nav.js
+++ b/app/services/get-sub-nav.js
@@ -1,12 +1,18 @@
 const Link = require('./domain/link')
 const linkGenerator = require('./helpers/link-generator')
 
-module.exports = function (id, organisationalUnitName) {
+module.exports = function (id, organisationalUnitName, currentPath) {
   var baseLink = linkGenerator.fromIdAndName(id, organisationalUnitName)
   var navigation = []
 
   navigation.push(new Link('Capacity', baseLink + '/caseload-capacity'))
   navigation.push(new Link('Case Progress', baseLink + '/case-progress'))
+
+  navigation.forEach(function (item) {
+    if (item.link === currentPath) {
+      item.active = true
+    }
+  })
 
   return navigation
 }

--- a/test/unit/services/test-get-capacity-view.js
+++ b/test/unit/services/test-get-capacity-view.js
@@ -76,28 +76,4 @@ describe('services/get-capacity-view', function () {
       done()
     })
   })
-  it('should call the sub nav service with the correct parameters', function (done) {
-    var id = 5
-    var organisationalUnitName = 'offender-manager'
-
-    getCapacityStub.resolves(CAPACITY_RESULTS)
-
-    getCapacityView(id, capacityDateRange, organisationalUnitName).then((result) => {
-      expect(getSubNav.calledWith(id, organisationalUnitName)).to.be.true //eslint-disable-line
-      done()
-    })
-  })
-  it('return the subnav object in the result', function (done) {
-    var id = 5
-    var organisationalUnitName = 'offender-manager'
-    var expectedSubNav = [{id: '1', link: 'link'}]
-
-    getSubNav.returns(expectedSubNav)
-    getCapacityStub.resolves(CAPACITY_RESULTS)
-
-    getCapacityView(id, capacityDateRange, organisationalUnitName).then((result) => {
-      expect(result.subNav).to.eql(expectedSubNav)
-      done()
-    })
-  })
 })

--- a/test/unit/services/test-get-sub-nav.js
+++ b/test/unit/services/test-get-sub-nav.js
@@ -29,4 +29,11 @@ describe('services/get-sub-nav', function () {
     expect(subNav[0].link).to.eql('/' + organisationalUnitName + '/' + id + '/' + 'caseload-capacity')
     expect(subNav[1].link).to.eql('/' + organisationalUnitName + '/' + id + '/' + 'case-progress')
   })
+
+  it('marks the current link as active', function () {
+    var currentLink = '/' + organisationalUnitName + '/' + id + '/' + 'caseload-capacity'
+    var subNav = getSubNav(id, organisationalUnitName, currentLink)
+    expect(subNav[0].active).to.be.true //eslint-disable-line
+    expect(subNav[1].active).to.be.undefined //eslint-disable-line
+  })
 })


### PR DESCRIPTION
The getSubNav call is going to be common across all of our screens. So it should
be as self contained as possible.

In stead of building up a list of navigation items in the service and then
setting the active flag on one, based on the req.path parameter, in the route.
The subNav array, including the active flag, is built in the get-sub-nav
service.

The service is then called only in the route, where we have access to the path.
This reduces the footprint of this common functionality and will make it easier
to bring new routes on board.