### PR TITLE
Use yarn scripts for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,4 @@ language: node_js
 node_js:
 - '6'
 cache: yarn
-before_script:
-  - yarn global add gulp
 script: yarn install && yarn unit-test

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,7 @@
 var gulp = require('gulp')
 var path = require('path')
-var mocha = require('gulp-mocha')
 var gulpNSP = require('gulp-nsp')
 var sass = require('gulp-sass')
-var standard = require('gulp-standard')
 var spawn = require('child_process').spawn
 var node
 
@@ -17,38 +15,6 @@ gulp.task('assets', function () {
   gulp.src('node_modules/govuk_template_jinja/assets/**/*')
     .pipe(gulp.dest('app/govuk_modules/govuk_template/', { overwrite: true }))
 })
-
-gulp.task('standard', function () {
-  return gulp.src([
-    '!node_modules/*',
-    '!app/govuk_modules/**/*.js',
-    '!app/assets/javascripts/**/*.js',
-    '!app/public/javascripts/**/*.js',
-    'app/**/*.js',
-    'test/**/*.js'
-  ])
-    .pipe(standard())
-    .pipe(standard.reporter('default', {
-      breakOnError: true,
-      quiet: true
-    }))
-})
-
-gulp.task('mocha-unit', function () {
-  return gulp.src(['test/unit/**/*.js'], { read: false })
-      .pipe(mocha({ reporter: 'spec' }))
-})
-
-gulp.task('mocha-integration', function () {
-  return gulp.src(['test/integration/**/*.js'], { read: false })
-      .pipe(mocha({ reporter: 'spec', timeout: 5000 }))
-})
-
-gulp.task('unit-test', ['standard', 'mocha-unit'])
-
-gulp.task('integration-test', ['mocha-integration'])
-
-gulp.task('test', ['unit-test', 'integration-test'])
 
 gulp.task('templates', function () {
   gulp.src('node_modules/govuk_template_jinja/views/layouts/govuk_template.html')

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "app/app.js",
   "scripts": {
     "start": "gulp",
-    "test": "gulp unit-test integration-test",
-    "unit-test": "gulp unit-test",
-    "integration-test": "gulp integration-test",
+    "unit-test": "standard && mocha --recursive test/unit/",
+    "integration-test": "mocha --recursive test/integration --timeout=10000",
+    "test": "yarn unit-test && yarn integration-test",
     "test-e2e": "gulp --gulpfile gulpfile-e2e.js"
   },
   "standard": {
@@ -30,7 +30,13 @@
   "devDependencies": {
     "cheerio": "^1.0.0-rc.2",
     "gulp-standard": "9.0.x",
-    "standard": "^10.0.2"
+    "mocha": "3.2.x",
+    "sinon": "^1.17.5",
+    "sinon-bluebird": "^3.1.0",
+    "standard": "^10.0.2",
+    "supertest": "3.0.x",
+    "wdio-mocha-framework": "^0.5.10",
+    "webdriverio": "^4.8.0"
   },
   "dependencies": {
     "body-parser": "1.17.x",
@@ -52,7 +58,6 @@
     "helmet": "^3.6.0",
     "knex": "0.12.x",
     "lodash": "^4.17.4",
-    "mocha": "3.2.x",
     "moment": "^2.18.1",
     "mssql": "3.3.0",
     "nunjucks": "3.0.x",
@@ -61,13 +66,8 @@
     "proxyquire": "1.7.x",
     "selenium-standalone": "^6.5.0",
     "serve-favicon": "2.4.x",
-    "sinon": "^1.17.5",
-    "sinon-bluebird": "^3.1.0",
-    "sql-cli": "^0.6.2",
-    "supertest": "3.0.x",
+    "underscore": "^1.8.3",
     "util": "^0.10.3",
-    "validator": "^7.0.0",
-    "wdio-mocha-framework": "^0.5.10",
-    "webdriverio": "^4.8.0"
+    "validator": "^7.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,7 +57,7 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-ansi-escapes@1.4.0, ansi-escapes@^1.1.0:
+ansi-escapes@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
@@ -189,7 +189,7 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asap@^2.0.0, asap@^2.0.3, asap@~2.0.3:
+asap@^2.0.3, asap@~2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
 
@@ -433,10 +433,6 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chardet@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.1.0.tgz#e266612d5b78262e998663ef17d06eb7a1b7b8c2"
-
 cheerio@^1.0.0-rc.2:
   version "1.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
@@ -655,13 +651,6 @@ crc@^3.4.4:
   version "3.4.4"
   resolved "https://registry.yarnpkg.com/crc/-/crc-3.4.4.tgz#9da1e980e3bd44fc5c93bf5ab3da3378d85e466b"
 
-cross-spawn@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.0.tgz#8254774ab4786b8c5b3cf4dfba66ce563932c252"
-  dependencies:
-    lru-cache "^4.0.1"
-    which "^1.2.9"
-
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
@@ -814,7 +803,7 @@ deepmerge@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.3.2.tgz#1663691629d4dbfe364fa12a2a4f0aa86aa3a050"
 
-defaults@^1.0.0, defaults@^1.0.3:
+defaults@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
   dependencies:
@@ -935,12 +924,6 @@ duplexer2@0.0.2:
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db"
   dependencies:
     readable-stream "~1.1.9"
-
-easy-table@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/easy-table/-/easy-table-1.1.0.tgz#86f9ab4c102f0371b7297b92a651d5824bc8cb73"
-  optionalDependencies:
-    wcwidth ">=1.0.1"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -2115,7 +2098,7 @@ https-proxy-agent@^1.0.0:
     debug "2"
     extend "3"
 
-iconv-lite@0.4.15, iconv-lite@^0.4.11, iconv-lite@^0.4.13:
+iconv-lite@0.4.15, iconv-lite@^0.4.11:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
@@ -2921,17 +2904,13 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-mssql@3.3.0, mssql@^3.3.0:
+mssql@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/mssql/-/mssql-3.3.0.tgz#b6e6337ff123e87bf8aee1e6c8344b53ca5da856"
   dependencies:
     generic-pool "^2.2.0"
     promise "^7.0.1"
     tedious "~1.14.0"
-
-mstring@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/mstring/-/mstring-0.1.2.tgz#8a268b1b2deade1e58e4d1eba5484a9fefafaf02"
 
 multipipe@^0.1.2:
   version "0.1.2"
@@ -3307,13 +3286,6 @@ parseurl@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
 
-password-prompt@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/password-prompt/-/password-prompt-1.0.2.tgz#49d050fa9fafe5f6e6b0643bcee949a43f78c014"
-  dependencies:
-    ansi-escapes "1.4.0"
-    cross-spawn "4.0.0"
-
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
@@ -3461,10 +3433,6 @@ pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
 
-pop-iterate@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/pop-iterate/-/pop-iterate-1.0.1.tgz#ceacfdab4abf353d7a0f2aaa2c1fc7b3f9413ba3"
-
 postgres-array@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-1.0.2.tgz#8e0b32eb03bf77a5c0a7851e0441c169a256a238"
@@ -3539,14 +3507,6 @@ punycode@1.3.2:
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-
-q@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/q/-/q-2.0.3.tgz#75b8db0255a1a5af82f58c3f3aaa1efec7d0d134"
-  dependencies:
-    asap "^2.0.0"
-    pop-iterate "^1.0.1"
-    weak-map "^1.0.5"
 
 q@~1.5.0:
   version "1.5.0"
@@ -4071,10 +4031,6 @@ split@^1.0.0:
   dependencies:
     through "2"
 
-sprintf-js@^1.0.3:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
-
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -4082,23 +4038,6 @@ sprintf-js@~1.0.2:
 sprintf@0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/sprintf/-/sprintf-0.1.5.tgz#8f83e39a9317c1a502cb7db8050e51c679f6edcf"
-
-sql-cli@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/sql-cli/-/sql-cli-0.6.2.tgz#8f74fa815192082aa42ae553493b3cebc9268f1b"
-  dependencies:
-    chardet "^0.1.0"
-    commander "^2.9.0"
-    easy-table "^1.0.0"
-    iconv-lite "^0.4.13"
-    mssql "^3.3.0"
-    mstring "^0.1.2"
-    password-prompt "^1.0.2"
-    q "^2.0.3"
-    sprintf-js "^1.0.3"
-    underscore "^1.8.3"
-    underscore.string "^3.3.4"
-    ya-csv "^0.9.4"
 
 sshpk@^1.7.0:
   version "1.13.1"
@@ -4466,13 +4405,6 @@ unc-path-regex@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
 
-underscore.string@^3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.3.4.tgz#2c2a3f9f83e64762fdc45e6ceac65142864213db"
-  dependencies:
-    sprintf-js "^1.0.3"
-    util-deprecate "^1.0.2"
-
 underscore@^1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
@@ -4514,7 +4446,7 @@ user-home@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
 
-util-deprecate@^1.0.2, util-deprecate@~1.0.1:
+util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
@@ -4601,12 +4533,6 @@ walkdir@^0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.0.11.tgz#a16d025eb931bd03b52f308caed0f40fcebe9532"
 
-wcwidth@>=1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
-  dependencies:
-    defaults "^1.0.3"
-
 wdio-dot-reporter@~0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/wdio-dot-reporter/-/wdio-dot-reporter-0.0.8.tgz#36195576da0d998210c71948cbb65f5bf11bfc65"
@@ -4626,10 +4552,6 @@ wdio-sync@0.6.14:
     babel-runtime "6.23.0"
     fibers "~1.0.15"
     object.assign "^4.0.3"
-
-weak-map@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/weak-map/-/weak-map-1.0.5.tgz#79691584d98607f5070bd3b70a40e6bb22e401eb"
 
 webdriverio@^4.8.0:
   version "4.8.0"
@@ -4725,10 +4647,6 @@ x-xss-protection@1.0.0:
 y18n@^3.2.0, y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-
-ya-csv@^0.9.4:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/ya-csv/-/ya-csv-0.9.4.tgz#9dda99bbd91d59477123943eff107634a6f7eb63"
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
Remove the use of gulp for test jobs. This keeps the build jobs simpiler and
consistent with `wmt-worker`.