### PR TITLE
698: Add national level capacity view

### DIFF
--- a/app/constants/organisation-unit.js
+++ b/app/constants/organisation-unit.js
@@ -3,5 +3,5 @@ module.exports = {
   TEAM: { name: 'team', ref: 'T', capacityView: 'team_capacity_view', displayText: 'Team' },
   LDU: { name: 'ldu', ref: 'L', capacityView: 'ldu_capacity_view', displayText: 'LDU' },
   REGION: { name: 'region', ref: 'R', capacityView: 'region_capacity_view', displayText: 'Region' },
-  NATIONAL: { name: 'nps', ref: 'N' }
+  NATIONAL: { name: 'hmpps', ref: 'N', capacityView: 'national_capacity_view', displayText: 'National' }
 }

--- a/app/routes/capacity-route.js
+++ b/app/routes/capacity-route.js
@@ -1,12 +1,17 @@
 const getCapacityView = require('../services/get-capacity-view')
 const dateRangeHelper = require('../services/helpers/date-range-helper')
 const getSubNav = require('../services/get-sub-nav')
+const organisationUnit = require('../constants/organisation-unit')
 
 module.exports = function (router) {
   router.get(`/:organisationLevel/:id/caseload-capacity`, function (req, res, next) {
     var capacityDateRange = dateRangeHelper.createCapacityDateRange(req.query)
-    var id = req.params.id
     var organisationLevel = req.params.organisationLevel
+    var id
+
+    if (organisationLevel !== organisationUnit.NATIONAL.name) {
+      id = req.params.id
+    }
 
     var capacityViewPromise = getCapacityView(id, capacityDateRange, organisationLevel)
 

--- a/app/services/data/get-workload-report-views.js
+++ b/app/services/data/get-workload-report-views.js
@@ -6,17 +6,23 @@ module.exports = function (id, fromDate, toDate, type) {
   var orgUnit = orgUnitFinder('name', type)
   var table = orgUnit.capacityView
 
+  var whereObject = {}
+
+  if (id !== undefined) {
+    whereObject.id = id
+  }
+
   return knex(table)
-    .where(table + '.id', id)
-    .where(table + '.effective_from', '>=', fromDate)
-    .where(table + '.effective_from', '<=', toDate)
-    .select(table + '.total_points',
-            table + '.sdr_points',
-            table + '.sdr_conversion_points',
-            table + '.paroms_points',
-            table + '.available_points',
-            table + '.effective_from',
-            table + '.reduction_hours')
+    .where(whereObject)
+    .where('effective_from', '>=', fromDate)
+    .where('effective_from', '<=', toDate)
+    .select('total_points',
+            'sdr_points',
+            'sdr_conversion_points',
+            'paroms_points',
+            'available_points',
+            'effective_from',
+            'reduction_hours')
     .then(function (results) {
       return results
     })

--- a/app/services/get-breadcrumbs.js
+++ b/app/services/get-breadcrumbs.js
@@ -20,6 +20,7 @@ module.exports = function (id, organisationLevel) {
     breadcrumbs.push(new Link(tree[reference].name, linkGenerator.fromReference(reference)))
     reference = tree[reference].parent
   } while (reference !== undefined)
+
   return breadcrumbs
 }
 

--- a/app/services/get-capacity-view.js
+++ b/app/services/get-capacity-view.js
@@ -11,7 +11,7 @@ module.exports = function (id, capacityDateRange, organisationLevel) {
   var workloadReportsPromise
 
   if (organisationalUnitType === undefined) {
-    throw new Error(organisationLevel + ' should be offender-manager, region, team or ldu')
+    throw new Error(organisationLevel + ' should be offender-manager, region, team, ldu or hmpps')
   }
 
   if (organisationLevel === routeType.OFFENDER_MANAGER.name) {

--- a/app/services/helpers/link-generator.js
+++ b/app/services/helpers/link-generator.js
@@ -31,7 +31,7 @@ module.exports.fromIdAndName = function (id, name) {
   var numberRegex = /^[0-9]+$/
 
   if (id === undefined || id === '') {
-    link = '/' + name
+    link = '/' + name + '/0'
   } else {
     if (!numberRegex.test(id.toString())) {
       throw new TypeError('ID must be a number')

--- a/app/services/organisational-hierarchy-tree.js
+++ b/app/services/organisational-hierarchy-tree.js
@@ -5,7 +5,7 @@ var tree
 
 module.exports.build = function () {
   tree = {}
-  tree[ROOT_REF] = { name: 'NPS', parent: undefined, children: [] }
+  tree[ROOT_REF] = { name: 'HMPPS', parent: undefined, children: [] }
 
   return getOrganisationalHierarchyData().then(function (result) {
     result.forEach(function (row) {

--- a/app/views/includes/breadcrumbs.html
+++ b/app/views/includes/breadcrumbs.html
@@ -1,4 +1,5 @@
 <div class="breadcrumbs">
+{% if breadcrumbs.length > 1 %}
   <ol>
   {% for breadcrumb in breadcrumbs.reverse() %}
     {% if loop.last %}
@@ -6,8 +7,7 @@
     {% else %}
       <li><a href="{{ breadcrumb.link }}">{{ breadcrumb.title }}</a></li>
     {% endif %}
-  {% else %}
-      <!-- <li>This would display if the breadcrumbs collection were empty</li> -->
   {% endfor %}
   </ol>
+{% endif %}
 </div>

--- a/test/helpers/breadcrumb-helper.js
+++ b/test/helpers/breadcrumb-helper.js
@@ -4,7 +4,7 @@ var offenderManagerBreadcrumb = new Link('John Doe', '/offender-manager/1')
 var teamBreadcrumb = new Link('Team 1', '/team/1')
 var lduBreadcrumb = new Link('LDU 1', '/ldu/1')
 var regionBreadcrumb = new Link('Region 1', '/region/1')
-var nationalBreadcrumb = new Link('NPS', '/nps')
+var nationalBreadcrumb = new Link('HMPPS', '/hmpps/0')
 
 module.exports.OFFENDER_MANAGER_BREADCRUMBS = [
   offenderManagerBreadcrumb,

--- a/test/helpers/organisational-hierarchy-helper.js
+++ b/test/helpers/organisational-hierarchy-helper.js
@@ -11,7 +11,7 @@ var baseRow = {
 }
 
 var baseTree = {
-  N: { name: 'NPS', parent: undefined, children: ['R1'] },
+  N: { name: 'HMPPS', parent: undefined, children: ['R1'] },
   R1: { name: 'Region 1', parent: 'N', children: ['L1'] },
   L1: { name: 'LDU 1', parent: 'R1', children: ['T1'] },
   T1: { name: 'Team 1', parent: 'L1', children: ['I1'] },
@@ -21,7 +21,7 @@ var baseTree = {
 module.exports.ROOT_REF = 'N'
 
 module.exports.ROOT_NODE = {
-  name: 'NPS',
+  name: 'HMPPS',
   parent: undefined,
   children: []
 }
@@ -58,7 +58,7 @@ module.exports.ORGANISATIONAL_HIERARCHY_DATA_MULTIPLE_BRANCHES = [
 ]
 
 module.exports.ORGANISATIONAL_HIERARCHY_TREE_MULTIPLE_BRANCHES = {
-  N: { parent: undefined, name: 'NPS', children: ['R1', 'R2'] },
+  N: { parent: undefined, name: 'HMPPS', children: ['R1', 'R2'] },
   R1: { parent: 'N', name: 'Region 1', children: ['L1', 'L2'] },
   L1: { parent: 'R1', name: 'LDU 1', children: ['T1', 'T2'] },
   T1: { parent: 'L1', name: 'Team 1', children: ['I1', 'I2'] },
@@ -84,7 +84,7 @@ module.exports.ORGANISATIONAL_HIERARCHY_DATA_NULL_VALUES = [
 ]
 
 module.exports.ORGANISATIONAL_HIERARCHY_TREE_NULL_VALUES = Object.assign({}, baseTree, {
-  N: { name: 'NPS', parent: undefined, children: ['R1', 'R2'] },
+  N: { name: 'HMPPS', parent: undefined, children: ['R1', 'R2'] },
   T1: { name: 'Team 1', parent: 'L1', children: ['I1', 'I3', 'I4'] },
   R2: { name: undefined, parent: 'N', children: ['L2'] },
   L2: { name: undefined, parent: 'R2', children: ['T2'] },

--- a/test/unit/services/test-get-breadcrumbs.js
+++ b/test/unit/services/test-get-breadcrumbs.js
@@ -52,8 +52,8 @@ describe('services/get-breadcrumbs', function () {
     }
     var getBreadcrumbs = proxyquire('../../../app/services/get-breadcrumbs', {'./organisational-hierarchy-tree': getTree})
 
-    expect(getBreadcrumbs(1, 'nps').length).to.eql(1)
-    expect(getBreadcrumbs(1, 'nps')).to.eql(breadcrumbDataHelper.NATIONAL_BREADCRUMBS)
+    expect(getBreadcrumbs(1, 'hmpps').length).to.eql(1)
+    expect(getBreadcrumbs(1, 'hmpps')).to.eql(breadcrumbDataHelper.NATIONAL_BREADCRUMBS)
   })
 
   it('should throw an error when passed an undefined organisation unit', function () {

--- a/test/unit/services/test-link-generator.js
+++ b/test/unit/services/test-link-generator.js
@@ -10,7 +10,7 @@ describe('services/helpers/link-generator', function () {
     })
 
     it('should return the correct link for national level (no ID)', function () {
-      expect(linkGenerator.fromReference('N')).to.eql('/nps')
+      expect(linkGenerator.fromReference('N')).to.eql('/hmpps/0')
     })
 
     it('should throw an error when passed undefined reference', function () {
@@ -34,8 +34,8 @@ describe('services/helpers/link-generator', function () {
     })
 
     it('should return no trailing slashes when an empty id is supplied', function () {
-      expect(linkGenerator.fromIdAndName(undefined, 'nps')).to.eql('/nps')
-      expect(linkGenerator.fromIdAndName('', 'nps')).to.eql('/nps')
+      expect(linkGenerator.fromIdAndName(undefined, 'hmpps')).to.eql('/hmpps/0')
+      expect(linkGenerator.fromIdAndName('', 'hmpps')).to.eql('/hmpps/0')
     })
 
     it('should throw an error when passed an invalid name', function () {


### PR DESCRIPTION
The caseload-capacity screen should be visable at a national level. This will
display the aggregated capacity for every offender manager in the system. As
there is only one instance of the national level, no id field is required.
However a dummy id `0` is used in order to keep the routing consistent.

Therefore the national level capacity screen is accessed from the path:

`/nps/0/caseload-capacity`