### PR TITLE
Add BASE_URL to end to end tests

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,5 +15,8 @@ module.exports = {
 
   // Migration
   MIGRATION_APP_DATABASE_USERNAME: process.env.WMT_MIGRATION_APP_DATABASE_USERNAME || 'wmt_app',
-  MIGRATION_APP_DATABASE_PASSWORD: process.env.WMT_MIGRATION_APP_DATABASE_PASSWORD || 'wmt_app'
+  MIGRATION_APP_DATABASE_PASSWORD: process.env.WMT_MIGRATION_APP_DATABASE_PASSWORD || 'wmt_app',
+
+  // E2E Tests
+  BASE_URL: process.env.WMT_BASE_URL || 'localhost:3000'
 }

--- a/test/e2e.conf.js
+++ b/test/e2e.conf.js
@@ -1,8 +1,10 @@
+const appConfig = require('../config.js')
+
 exports.config = {
   specs: ['./test/e2e/**/*.js'],
   exclude: [],
   maxInstances: 1,
-  baseUrl: 'http://localhost:3000',
+  baseUrl: appConfig.BASE_URL,
   capabilities: [{
     maxInstances: 1,
     browserName: 'chrome'


### PR DESCRIPTION
This will allow our end to end tests to be run on a variety of environments and
configured using the `WMT_BASE_URL` environment variable