### PR TITLE
Make the log level of the webdriver verbose

### DIFF
--- a/gulpfile-e2e.js
+++ b/gulpfile-e2e.js
@@ -16,7 +16,8 @@ gulp.task('selenium', (done) => {
 
 gulp.task('e2e', ['selenium'], () => {
   return gulp.src('test/e2e.conf.js')
-    .pipe(webdriver()).on('error', () => {
+    .pipe(webdriver({logLevel: 'verbose'}))
+    .on('error', () => {
       seleniumServer.kill()
       process.exit(1)
     })


### PR DESCRIPTION
This is to debug issues with the webdriver runs on jenkins