### PR TITLE
Revert end to end test debugging changes

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,8 +15,5 @@ module.exports = {
 
   // Migration
   MIGRATION_APP_DATABASE_USERNAME: process.env.WMT_MIGRATION_APP_DATABASE_USERNAME || 'wmt_app',
-  MIGRATION_APP_DATABASE_PASSWORD: process.env.WMT_MIGRATION_APP_DATABASE_PASSWORD || 'wmt_app',
-
-  // E2E Tests
-  BASE_URL: process.env.WMT_BASE_URL || 'http://localhost:3000'
+  MIGRATION_APP_DATABASE_PASSWORD: process.env.WMT_MIGRATION_APP_DATABASE_PASSWORD || 'wmt_app'
 }

--- a/gulpfile-e2e.js
+++ b/gulpfile-e2e.js
@@ -16,8 +16,7 @@ gulp.task('selenium', (done) => {
 
 gulp.task('e2e', ['selenium'], () => {
   return gulp.src('test/e2e.conf.js')
-    .pipe(webdriver({logLevel: 'verbose'}))
-    .on('error', () => {
+    .pipe(webdriver()).on('error', () => {
       seleniumServer.kill()
       process.exit(1)
     })

--- a/test/e2e.conf.js
+++ b/test/e2e.conf.js
@@ -1,13 +1,11 @@
-const appConfig = require('../config.js')
-
 exports.config = {
   specs: ['./test/e2e/**/*.js'],
   exclude: [],
   maxInstances: 1,
-  baseUrl: appConfig.BASE_URL,
+  baseUrl: process.env.WMT_BASE_URL || 'http://localhost:3000',
   capabilities: [{
     maxInstances: 1,
-    browserName: 'phantomjs'
+    browserName: 'chrome'
   }],
   sync: false,
   logLevel: 'verbose',


### PR DESCRIPTION
The end to end tests are currently failing on Jenkins because they require a
headless browser, such as PhantomJS.

The long term plan for this will be to use saucelabs to run on a series of
browsers. We are content to wait for this change to be played instead of
installing the drivers required to use a headless browser in Jenkins.