### PR TITLE
Hotfix: Fixes issue of intermittant failing e2e test 'view existing r…

### DIFF
--- a/test/helpers/data/aggregated-data-helper.js
+++ b/test/helpers/data/aggregated-data-helper.js
@@ -335,7 +335,7 @@ module.exports.getAnyExistingWorkloadOwnerIdWithActiveReduction = function () {
   return knex('workload_owner')
       .join('reductions', 'workload_owner.id', 'workload_owner_id')
       .where('effective_to', '>', knex.raw('GETDATE()'))
-      .andWhereNot('status', 'DELETED' )
+      .andWhereNot('status', 'DELETED')
       .first('workload_owner.id AS workloadOwnerId',
        'reductions.id AS reductionId')
 }

--- a/test/helpers/data/aggregated-data-helper.js
+++ b/test/helpers/data/aggregated-data-helper.js
@@ -335,6 +335,7 @@ module.exports.getAnyExistingWorkloadOwnerIdWithActiveReduction = function () {
   return knex('workload_owner')
       .join('reductions', 'workload_owner.id', 'workload_owner_id')
       .where('effective_to', '>', knex.raw('GETDATE()'))
+      .andWhereNot('status', 'DELETED' )
       .first('workload_owner.id AS workloadOwnerId',
        'reductions.id AS reductionId')
 }


### PR DESCRIPTION
…eduction'

Modifies the getWorkloadOwnerWithExistingActiveReduction to filter out any deleted reductions