### PR TITLE
Remove configuration dependency from unit tests

### DIFF
--- a/app/routes/admin.js
+++ b/app/routes/admin.js
@@ -7,13 +7,18 @@ const fieldValidator = require('../services/validators/field-validator')
 const errorHandler = require('../services/validators/error-handler')
 
 module.exports = function (router) {
-  router.get('/admin', function (req, res) {
+  router.get('/admin', function (req, res, next) {
     var userRole
     try {
       if (authorisation.hasRole(req, roles.DATA_ADMIN)) {
         userRole = roles.DATA_ADMIN
       } else if (authorisation.hasRole(req, roles.SYSTEM_ADMIN)) {
         userRole = roles.SYSTEM_ADMIN
+      } else {
+        res.status(403)
+        return res.render('includes/error', {
+          error: 'Admin roles required'
+        })
       }
       return res.render('admin', {
         title: 'Admin',

--- a/test/unit/routes/test-admin.js
+++ b/test/unit/routes/test-admin.js
@@ -26,21 +26,34 @@ const ADMIN_USER_RIGHT_ROLES_URL = '/admin/user-rights/'
 var app
 var route
 var userRoleService
+var authorisationService
+var hasRoleResult = true
 
-before(function () {
+var initaliseApp = function () {
   userRoleService = sinon.stub()
+  authorisationService = {
+    hasRole: sinon.stub().returns(hasRoleResult)
+  }
   route = proxyquire('../../../app/routes/admin', {
     '../services/user-role-service': userRoleService,
-    '../../../config': {
-      AUTHENTICATION_ENABLED: true
-    }
+    '../authorisation': authorisationService
   })
   app = routeHelper.buildApp(route)
+}
+
+before(function () {
+  initaliseApp()
 })
 
 describe('admin route', function () {
-  it('should respond with 302, redirect to AD login page', function () {
-    return supertest(app).get(ADMIN_URL).expect(302)
+  it('should respond with 200 when the user has the admin role', function () {
+    return supertest(app).get(ADMIN_URL).expect(200)
+  })
+
+  it('should respond with 403 when the user does not have the admin role', function () {
+    hasRoleResult = false
+    initaliseApp()
+    return supertest(app).get(ADMIN_URL).expect(403)
   })
 
   it('should respond with 200 when user right is called', function () {

--- a/test/unit/routes/test-admin.js
+++ b/test/unit/routes/test-admin.js
@@ -30,14 +30,17 @@ var userRoleService
 before(function () {
   userRoleService = sinon.stub()
   route = proxyquire('../../../app/routes/admin', {
-    '../services/user-role-service': userRoleService
+    '../services/user-role-service': userRoleService,
+    '../../../config': {
+      AUTHENTICATION_ENABLED: true
+    }
   })
   app = routeHelper.buildApp(route)
 })
 
 describe('admin route', function () {
-  it('should respond with 200, redirect to AD login page', function () {
-    return supertest(app).get(ADMIN_URL).expect(200)
+  it('should respond with 302, redirect to AD login page', function () {
+    return supertest(app).get(ADMIN_URL).expect(302)
   })
 
   it('should respond with 200 when user right is called', function () {


### PR DESCRIPTION
The admin route unit test would fail or pass depending on the environment
variables on a given environment. This change will ensure that the configuration
remains consistent regardless of the underlying environment variables.