### PR TITLE
Create one knex instance per user instead of one per file.

### DIFF
--- a/app/services/data/create-calculate-workload-points-task.js
+++ b/app/services/data/create-calculate-workload-points-task.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (workloadStagingId, workloadReportId, batchSize) {
   var newTask = {

--- a/app/services/data/get-capacity-breakdown.js
+++ b/app/services/data/get-capacity-breakdown.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 const orgUnitFinder = require('../helpers/org-unit-finder')
 
 module.exports = function (id, type) {

--- a/app/services/data/get-caseload-progress.js
+++ b/app/services/data/get-caseload-progress.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 const orgUnitFinder = require('../helpers/org-unit-finder')
 
 module.exports = function (id, type) {

--- a/app/services/data/get-caseload.js
+++ b/app/services/data/get-caseload.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 const orgUnitFinder = require('../helpers/org-unit-finder')
 
 module.exports = function (id, type) {

--- a/app/services/data/get-contracted-hours-for-workload-owner.js
+++ b/app/services/data/get-contracted-hours-for-workload-owner.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (workloadOwnerId) {
   return knex('workload_owner')

--- a/app/services/data/get-ids-for-workload-points-recalc.js
+++ b/app/services/data/get-ids-for-workload-points-recalc.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (previousWorkloadPointsId) {
   return knex('workload_report')

--- a/app/services/data/get-individual-overview.js
+++ b/app/services/data/get-individual-overview.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (id) {
   return knex('individual_case_overview')

--- a/app/services/data/get-latest-workload-staging-id-and-workload-report-id.js
+++ b/app/services/data/get-latest-workload-staging-id-and-workload-report-id.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (id) {
   return knex('workload_owner')

--- a/app/services/data/get-organisation-overview.js
+++ b/app/services/data/get-organisation-overview.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 const orgUnitFinder = require('../helpers/org-unit-finder')
 const orgUnitConstants = require('../../constants/organisation-unit')
 

--- a/app/services/data/get-organisational-hierarchy-data.js
+++ b/app/services/data/get-organisational-hierarchy-data.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function () {
   return knex('workload_owner')

--- a/app/services/data/get-reduction-by-id.js
+++ b/app/services/data/get-reduction-by-id.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (id) {
   var whereObject = {}

--- a/app/services/data/get-reduction-reasons.js
+++ b/app/services/data/get-reduction-reasons.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function () {
   return knex('reduction_reason')

--- a/app/services/data/get-reductions.js
+++ b/app/services/data/get-reductions.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (workloadOwnerId) {
   var whereObject = {}

--- a/app/services/data/get-role.js
+++ b/app/services/data/get-role.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (roleName) {
   if (roleName === undefined) {

--- a/app/services/data/get-user-by-id.js
+++ b/app/services/data/get-user-by-id.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (id) {
   if (id === undefined) {

--- a/app/services/data/get-user-by-username.js
+++ b/app/services/data/get-user-by-username.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (username) {
   if (username === undefined) {

--- a/app/services/data/get-user-role-by-username.js
+++ b/app/services/data/get-user-role-by-username.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 const Roles = require('../../constants/user-roles')
 
 module.exports = function (username) {

--- a/app/services/data/get-workload-points.js
+++ b/app/services/data/get-workload-points.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function () {
   return knex('workload_points')

--- a/app/services/data/get-workload-report-views.js
+++ b/app/services/data/get-workload-report-views.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 const orgUnitFinder = require('../helpers/org-unit-finder')
 
 module.exports = function (id, fromDate, toDate, type) {

--- a/app/services/data/insert-reduction.js
+++ b/app/services/data/insert-reduction.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (id, newReduction) {
   return knex('reductions')

--- a/app/services/data/insert-user-role.js
+++ b/app/services/data/insert-user-role.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (newUserRole) {
   return knex('user_role')

--- a/app/services/data/insert-user.js
+++ b/app/services/data/insert-user.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (username, name) {
   return knex('users')

--- a/app/services/data/insert-workload-points.js
+++ b/app/services/data/insert-workload-points.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (workloadPoints) {
   return knex('workload_points')

--- a/app/services/data/remove-user-by-username.js
+++ b/app/services/data/remove-user-by-username.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (username) {
   if (username === undefined) {

--- a/app/services/data/remove-user-role-by-user-id.js
+++ b/app/services/data/remove-user-role-by-user-id.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (userId) {
   if (userId === undefined) {

--- a/app/services/data/update-contracted-hours-for-workload-owner.js
+++ b/app/services/data/update-contracted-hours-for-workload-owner.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (id, hours) {
   return knex('workload_owner').where('id', id)

--- a/app/services/data/update-reduction-status.js
+++ b/app/services/data/update-reduction-status.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (reductionId, reductionStatus) {
   return knex('reductions')

--- a/app/services/data/update-reduction.js
+++ b/app/services/data/update-reduction.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (reductionId, workloadOwnerId, newReduction) {
   return knex('reductions')

--- a/app/services/data/update-user-role.js
+++ b/app/services/data/update-user-role.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (userId, roleId, updatedBy) {
   if (userId === undefined) {

--- a/app/services/data/update-workload-points-effective-to.js
+++ b/app/services/data/update-workload-points-effective-to.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (workloadPointsId) {
   return knex('workload_points')

--- a/knex.js
+++ b/knex.js
@@ -1,0 +1,5 @@
+const knexWebSchema = require('knex')(require('./knexfile').web)
+
+module.exports = {
+  web: knexWebSchema
+}

--- a/test/accessibility/test-accessibility-pa11y.js
+++ b/test/accessibility/test-accessibility-pa11y.js
@@ -1,5 +1,4 @@
-const config = require('../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../knex').web
 const shelljs = require('shelljs')
 const expect = require('chai').expect
 

--- a/test/helpers/data/aggregated-data-helper.js
+++ b/test/helpers/data/aggregated-data-helper.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').integrationTests
-const knex = require('knex')(config)
+const knex = require('../../knex').integrationTests
 var Promise = require('bluebird').Promise
 const _ = require('lodash')
 

--- a/test/helpers/data/organisational-hierarchy-db-helper.js
+++ b/test/helpers/data/organisational-hierarchy-db-helper.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').integrationTests
-const knex = require('knex')(config)
+const knex = require('../../knex').integrationTests
 var Promise = require('bluebird').Promise
 
 module.exports.addOrganisationalHierachy = function () {

--- a/test/helpers/data/ref-data-helper.js
+++ b/test/helpers/data/ref-data-helper.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').integrationTests
-const knex = require('knex')(config)
+const knex = require('../../knex').integrationTests
 var Promise = require('bluebird').Promise
 
 module.exports.addReductionsRefData = function (maxId) {

--- a/test/helpers/data/user-role-helper.js
+++ b/test/helpers/data/user-role-helper.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').integrationTests
-const knex = require('knex')(config)
+const knex = require('../../knex').integrationTests
 var Promise = require('bluebird').Promise
 
 module.exports.addUserRoleData = function (userId, roleId) {

--- a/test/integration/services/data/test-get-workload-points.js
+++ b/test/integration/services/data/test-get-workload-points.js
@@ -1,6 +1,5 @@
 const expect = require('chai').expect
-const config = require('../../../../knexfile').integrationTests
-const knex = require('knex')(config)
+const knex = require('../../../knex').integrationTests
 
 const dataHelper = require('../../../helpers/data/aggregated-data-helper')
 const getWorkloadPoints = require('../../../../app/services/data/get-workload-points')

--- a/test/integration/services/data/test-get-workload-reports-views.js
+++ b/test/integration/services/data/test-get-workload-reports-views.js
@@ -1,6 +1,5 @@
 const expect = require('chai').expect
-const config = require('../../../../knexfile').integrationTests
-const knex = require('knex')(config)
+const knex = require('../../../knex').integrationTests
 
 const dataHelper = require('../../../helpers/data/aggregated-data-helper')
 const getWorkloadReportsViews = require('../../../../app/services/data/get-workload-report-views')

--- a/test/knex.js
+++ b/test/knex.js
@@ -1,0 +1,5 @@
+const knex = require('knex')(require('../knexfile').integrationTests)
+
+module.exports = {
+  integrationTests: knex
+}


### PR DESCRIPTION
Before this change the application created a new knex instance, and therefore a
new connection pool, each time it was reference from a file. That means we
couldn't control the size of the pool for the application.

The web application should only create one pool during normal operation. This is
done in the new `knex.js` file in the root of the project.

The integration tests will require a different pool whose connections use a user
with higher permissions. To achieve this another `knex.js` file was created in
the `test/` directory.