### PR TITLE
1212: Remove getContractedHours as it references redundant fields.

### DIFF
--- a/app/services/get-overview.js
+++ b/app/services/get-overview.js
@@ -2,8 +2,6 @@ const getBreadcrumbs = require('./get-breadcrumbs')
 const getOrganisationUnit = require('./helpers/org-unit-finder')
 const getIndividualOverview = require('./data/get-individual-overview')
 const getOrganisationOverview = require('./data/get-organisation-overview')
-const calculateContractedHours = require('wmt-probation-rules').calculateContractedHours
-const DefaultContractedHours = require('wmt-probation-rules').DefaultContractedHours
 const orgUnit = require('../constants/organisation-unit')
 
 module.exports = function (id, organisationLevel) {
@@ -33,26 +31,10 @@ var calculateValues = function (results) {
       if (result.availablePoints > 0) {
         result.capacityPercentage = (result.totalPoints / result.availablePoints) * 100
       }
-      if (result.contractedHours === 0) {
-        result.contractedHours = getContractedHours(result)
-      }
     })
     return results
   } else {
     var capacityPercentage = (results.totalPoints / results.availablePoints) * 100
-    if (results.contractedHours === 0) {
-      results.contractedHours = getContractedHours(results)
-    }
     return Object.assign({}, results, {capacity: capacityPercentage})
-  }
-}
-
-var getContractedHours = function (result) {
-  var defaultContractedHours = new DefaultContractedHours(result.defaultContractedHoursPo, result.defaultContractedHoursPso)
-  var resultHours = calculateContractedHours(result.contractedHours, defaultContractedHours)
-  if (resultHours.baseHours !== null) {
-    return resultHours.baseHours
-  } else {
-    return resultHours.defaultContractedHoursForBand
   }
 }

--- a/test/unit/services/test-get-overview.js
+++ b/test/unit/services/test-get-overview.js
@@ -17,30 +17,14 @@ const OVERVIEW = {
   cases: '2',
   hours: '3',
   reduction: '4',
-  contractedHours: 37,
-  defaultContractedHoursPo: 3,
-  defaultContractedHoursPso: 0
+  contractedHours: 37
 }
 const ORGANISATION_OVERVIEWS = [
   Object.assign({}, OVERVIEW, {capacityPercentage: 80}), Object.assign({}, OVERVIEW, {capacityPercentage: 80})
 ]
 
-var ZERO_AVAILABLE_POINTS_OVERVIEW = {
-  grade: 'PO',
-  teamId: '1',
-  teamName: 'Medway',
-  availablePoints: 0,
-  totalPoints: 40,
-  cases: '2',
-  hours: '3',
-  reduction: '4',
-  contractedHours: 37,
-  defaultContractedHoursPo: 3,
-  defaultContractedHoursPso: 0
-}
-
 const ZERO_AVAILABLE_POINTS_OVERVIEWS = [
-  Object.assign({}, ZERO_AVAILABLE_POINTS_OVERVIEW, {capacity: 0})
+  Object.assign({}, OVERVIEW, {capacity: 0, availablePoints: 0})
 ]
 
 var expectedOverview = Object.assign({}, OVERVIEW, {capacity: 80})
@@ -142,6 +126,16 @@ describe('services/get-overview', function () {
       assert(!getIndividualOverview.called)
       assert(getOrganisationOverview.called)
       expect(result.overviewDetails).to.eql(ZERO_AVAILABLE_POINTS_OVERVIEWS)
+    })
+  })
+
+  it('should 0 contracted hours if there are indeed 0 contracted hours', function () {
+    var orgName = orgUnitConstant.REGION.name
+    var zeroContractedHours = Object.assign({}, OVERVIEW, {contractedHours: 0})
+    getOrganisationOverview.withArgs(id, orgName).resolves([zeroContractedHours])
+
+    return getOverview(id, orgName).then(function (result) {
+      expect(result.overviewDetails).to.eql([zeroContractedHours])
     })
   })
 })


### PR DESCRIPTION
The application was giving regions with 0 contracted hours e.g. `Stakeholder
Engagement London` the default number of contracted hours for a PO or PSO. There
are some instances however, where the number of contracted hours should indeed
be 0. This is when migrated data has been brought over and there are regions
with no LDUs associated with them.