### PR TITLE
Remove conversion of date to string as it already gets parsed.

### DIFF
--- a/app/services/data/get-workload-report-views.js
+++ b/app/services/data/get-workload-report-views.js
@@ -13,8 +13,8 @@ module.exports = function (id, fromDate, toDate, type) {
     'contracted_hours'
   ]
 
-  var whereString = ' WHERE effective_from >= \'' + fromDate.toISOString() + '\''
-  whereString += ' AND effective_from <= \'' + toDate.toISOString() + '\''
+  var whereString = ' WHERE effective_from >= \'' + fromDate + '\''
+  whereString += ' AND effective_from <= \'' + toDate + '\''
 
   if (id !== undefined && (!isNaN(parseInt(id, 10)))) {
     whereString += ' AND id = ' + id

--- a/test/integration/services/data/test-get-workload-reports-views.js
+++ b/test/integration/services/data/test-get-workload-reports-views.js
@@ -35,11 +35,11 @@ describe('services/data/get-workload-report-views', function () {
     .then(function () {
       return dataHelper.getWorkloadReportEffectiveFromDate()
       .then(function (result) {
-        startDate = result.effective_from
-        endDate = new Date((startDate.getTime() + 360 * ONE_DAY_IN_MS))
+        startDate = result.effective_from.toISOString()
+        endDate = new Date((result.effective_from.getTime() + 360 * ONE_DAY_IN_MS)).toISOString()
         expectedResults = [
           {
-            effective_from: startDate,
+            effective_from: new Date(startDate),
             total_points: 50,
             available_points: 25,
             reduction_hours: 3,


### PR DESCRIPTION
In the get-workload-report-view a start and end date are passed as strings.
These are then passed to the query.

The tests were passing date objects and therefore tests were failing until they
were converted to strings.

In the implementation however, the dates are converted to strings before they're
passed meaning the view was erroring out.