### PR TITLE
Format capacity percentage figure being exported to csv

### DIFF
--- a/app/services/get-export-csv.js
+++ b/app/services/get-export-csv.js
@@ -89,9 +89,13 @@ var getCsv = function (organisationLevel, result, tab, fields, fieldNames) {
       }
       break
     case tabs.OVERVIEW:
-      result.overviewDetails.forEach(function(item) {
-        item.capacityPercentage = parseFloat(item.capacityPercentage).toFixed(2) + '%'
-      })
+      if(Array.isArray(result.overviewDetails)) {
+        result.overviewDetails.forEach(function(item) {
+          item.capacityPercentage = formatCapacityValue(item.capacityPercentage)
+        })
+      } else {
+        result.overviewDetails.capacity = formatCapacityValue(result.overviewDetails.capacity)
+      }
       csv = generateCsv(result.overviewDetails, fields, fieldNames)
       break
   }
@@ -147,4 +151,8 @@ var parseTotalSummaryTable = function (totalSummary) {
   })
 
   return table
+}
+
+var formatCapacityValue = function (capacity) {
+  return parseFloat(capacity).toFixed(2) + '%'
 }

--- a/app/services/get-export-csv.js
+++ b/app/services/get-export-csv.js
@@ -89,12 +89,12 @@ var getCsv = function (organisationLevel, result, tab, fields, fieldNames) {
       }
       break
     case tabs.OVERVIEW:
-      if (Array.isArray(result.overviewDetails)) {
+      if (organisationLevel === organisationUnitConstants.OFFENDER_MANAGER.name) {
+        result.overviewDetails.capacity = formatCapacityValue(result.overviewDetails.capacity)
+      } else {
         result.overviewDetails.forEach(function (item) {
           item.capacityPercentage = formatCapacityValue(item.capacityPercentage)
         })
-      } else {
-        result.overviewDetails.capacity = formatCapacityValue(result.overviewDetails.capacity)
       }
       csv = generateCsv(result.overviewDetails, fields, fieldNames)
       break

--- a/app/services/get-export-csv.js
+++ b/app/services/get-export-csv.js
@@ -89,6 +89,9 @@ var getCsv = function (organisationLevel, result, tab, fields, fieldNames) {
       }
       break
     case tabs.OVERVIEW:
+      for(var i = 0; i < result.overviewDetails.length; i++) {
+        result.overviewDetails[i].capacityPercentage = result.overviewDetails[i].capacityPercentage.toFixed(2) + '%'
+      }
       csv = generateCsv(result.overviewDetails, fields, fieldNames)
       break
   }

--- a/app/services/get-export-csv.js
+++ b/app/services/get-export-csv.js
@@ -89,9 +89,9 @@ var getCsv = function (organisationLevel, result, tab, fields, fieldNames) {
       }
       break
     case tabs.OVERVIEW:
-      for(var i = 0; i < result.overviewDetails.length; i++) {
-        result.overviewDetails[i].capacityPercentage = result.overviewDetails[i].capacityPercentage.toFixed(2) + '%'
-      }
+      result.overviewDetails.forEach(function(item) {
+        item.capacityPercentage = parseFloat(item.capacityPercentage).toFixed(2) + '%'
+      })
       csv = generateCsv(result.overviewDetails, fields, fieldNames)
       break
   }

--- a/app/services/get-export-csv.js
+++ b/app/services/get-export-csv.js
@@ -89,8 +89,8 @@ var getCsv = function (organisationLevel, result, tab, fields, fieldNames) {
       }
       break
     case tabs.OVERVIEW:
-      if(Array.isArray(result.overviewDetails)) {
-        result.overviewDetails.forEach(function(item) {
+      if (Array.isArray(result.overviewDetails)) {
+        result.overviewDetails.forEach(function (item) {
           item.capacityPercentage = formatCapacityValue(item.capacityPercentage)
         })
       } else {

--- a/test/helpers/export-csv-helper.js
+++ b/test/helpers/export-csv-helper.js
@@ -227,7 +227,7 @@ module.exports.OM_OVERVIEW_RESULT = {
 module.exports.OM_OVERVIEW_CSV = {
   filename: 'John_Smith_Overview.csv',
   csv: '"GradeCode","TeamName","CapacityPercentage","TotalCases","ContractedHours","ReductionHours"\n' +
-  '"PO","Team 1",105,60,37,4'
+  '"PO","Team 1","105.00%",60,37,4'
 }
 
 module.exports.TEAM_OVERVIEW_RESULT = {
@@ -256,8 +256,8 @@ module.exports.TEAM_OVERVIEW_RESULT = {
 module.exports.TEAM_OVERVIEW_CSV = {
   filename: 'Test_Team_Overview.csv',
   csv: '"OffenderManagerName","CapacityPercentage","CapacityPoints","ContractedHours","ReductionHours","TotalCases","GradeCode"\n' +
-  '"John Smith",107.36842105263158,190,37.5,6,63,"PO"\n' +
-  '"Tony Test",106.84210526315789,190,36.5,6,63,"PO"'
+  '"John Smith","107.37%",190,37.5,6,63,"PO"\n' +
+  '"Tony Test","106.84%",190,36.5,6,63,"PO"'
 }
 
 module.exports.LDU_OVERVIEW_RESULT = {
@@ -284,8 +284,8 @@ module.exports.LDU_OVERVIEW_RESULT = {
 module.exports.LDU_OVERVIEW_CSV = {
   filename: 'Test_LDU_Overview.csv',
   csv: '"TeamName","CapacityPercentage","CapacityPoints","ContractedHours","ReductionHours","TotalCases"\n' +
-  '"Team 1",106.73684210526315,950,175.5,30,315\n' +
-  '"Team 4",106.73684210526315,950,175.5,28,315'
+  '"Team 1","106.74%",950,175.5,30,315\n' +
+  '"Team 4","106.74%",950,175.5,28,315'
 }
 
 module.exports.REGION_OVERVIEW_HEADINGS = '"LDUClusterName","CapacityPercentage","CapacityPoints","ContractedHours","ReductionHours","TotalCases"'

--- a/test/unit/services/test-get-export-csv.js
+++ b/test/unit/services/test-get-export-csv.js
@@ -37,17 +37,17 @@ describe('services/get-export-csv', function () {
     })
   })
   describe('should format the capacity when exporting overviews', function () {
-    it('should be formatted to two decimal figures', function () {
+    it('to two decimal figures', function () {
       var capacityExport = getExportCsv(orgUnit.TEAM.name, helper.TEAM_OVERVIEW_RESULT, tabs.OVERVIEW).csv
       expect(capacityExport).to.include('107.37')
       expect(capacityExport).to.include('106.84')
     })
-    it('should be appended with a percentage symbol', function () {
+    it('with a percentage symbol', function () {
       var capacityExport = getExportCsv(orgUnit.TEAM.name, helper.TEAM_OVERVIEW_RESULT, tabs.OVERVIEW).csv
       expect(capacityExport).to.include('107.37%')
       expect(capacityExport).to.include('106.84%')
     })
-    it('should also format capacity when exporting individual OM overview', function () {
+    it('for Offender Manager overview', function () {
       var capacityExport = getExportCsv(orgUnit.OFFENDER_MANAGER.name, helper.OM_OVERVIEW_RESULT, tabs.OVERVIEW).csv
       expect(capacityExport).to.include('105.00%')
     })

--- a/test/unit/services/test-get-export-csv.js
+++ b/test/unit/services/test-get-export-csv.js
@@ -36,4 +36,21 @@ describe('services/get-export-csv', function () {
       expect(getExportCsv(orgUnit.NATIONAL.name, helper.LDU_OVERVIEW_RESULT, tabs.OVERVIEW).csv).to.include(helper.NATIONAL_OVERVIEW_HEADINGS)
     })
   })
+  describe('should format the capacity when exporting overviews', function() {
+    it('should be formatted to two decimal figures', function() {
+      var capacityExport = getExportCsv(orgUnit.TEAM.name, helper.TEAM_OVERVIEW_RESULT, tabs.OVERVIEW).csv
+      expect(capacityExport).to.include('107.37')
+      expect(capacityExport).to.include('106.84')
+    })
+    it('should be appended with a percentage symbol', function() {
+      var capacityExport = getExportCsv(orgUnit.TEAM.name, helper.TEAM_OVERVIEW_RESULT, tabs.OVERVIEW).csv
+      expect(capacityExport).to.include('107.37%')
+      expect(capacityExport).to.include('106.84%')
+    })
+    it('should be appended with a percentage symbol with LDU', function() {
+      var capacityExport = getExportCsv(orgUnit.LDU.name, helper.LDU_OVERVIEW_RESULT, tabs.OVERVIEW).csv
+      expect(capacityExport).to.include('106.74%')
+      expect(capacityExport).to.include('106.74%')
+    })
+  })
 })

--- a/test/unit/services/test-get-export-csv.js
+++ b/test/unit/services/test-get-export-csv.js
@@ -39,8 +39,8 @@ describe('services/get-export-csv', function () {
   describe('should format the capacity when exporting overviews', function () {
     it('to two decimal figures', function () {
       var capacityExport = getExportCsv(orgUnit.TEAM.name, helper.TEAM_OVERVIEW_RESULT, tabs.OVERVIEW).csv
-      expect(capacityExport).to.include('107.37')
-      expect(capacityExport).to.include('106.84')
+      expect(capacityExport).to.include('107.37%')
+      expect(capacityExport).to.include('106.84%')
     })
     it('with a percentage symbol', function () {
       var capacityExport = getExportCsv(orgUnit.TEAM.name, helper.TEAM_OVERVIEW_RESULT, tabs.OVERVIEW).csv

--- a/test/unit/services/test-get-export-csv.js
+++ b/test/unit/services/test-get-export-csv.js
@@ -47,10 +47,9 @@ describe('services/get-export-csv', function () {
       expect(capacityExport).to.include('107.37%')
       expect(capacityExport).to.include('106.84%')
     })
-    it('should be appended with a percentage symbol with LDU', function() {
-      var capacityExport = getExportCsv(orgUnit.LDU.name, helper.LDU_OVERVIEW_RESULT, tabs.OVERVIEW).csv
-      expect(capacityExport).to.include('106.74%')
-      expect(capacityExport).to.include('106.74%')
+    it('should also format capacity when exporting individual OM overview', function() {
+      var capacityExport = getExportCsv(orgUnit.OFFENDER_MANAGER.name, helper.OM_OVERVIEW_RESULT, tabs.OVERVIEW).csv
+      expect(capacityExport).to.include('105.00%')
     })
   })
 })

--- a/test/unit/services/test-get-export-csv.js
+++ b/test/unit/services/test-get-export-csv.js
@@ -36,18 +36,18 @@ describe('services/get-export-csv', function () {
       expect(getExportCsv(orgUnit.NATIONAL.name, helper.LDU_OVERVIEW_RESULT, tabs.OVERVIEW).csv).to.include(helper.NATIONAL_OVERVIEW_HEADINGS)
     })
   })
-  describe('should format the capacity when exporting overviews', function() {
-    it('should be formatted to two decimal figures', function() {
+  describe('should format the capacity when exporting overviews', function () {
+    it('should be formatted to two decimal figures', function () {
       var capacityExport = getExportCsv(orgUnit.TEAM.name, helper.TEAM_OVERVIEW_RESULT, tabs.OVERVIEW).csv
       expect(capacityExport).to.include('107.37')
       expect(capacityExport).to.include('106.84')
     })
-    it('should be appended with a percentage symbol', function() {
+    it('should be appended with a percentage symbol', function () {
       var capacityExport = getExportCsv(orgUnit.TEAM.name, helper.TEAM_OVERVIEW_RESULT, tabs.OVERVIEW).csv
       expect(capacityExport).to.include('107.37%')
       expect(capacityExport).to.include('106.84%')
     })
-    it('should also format capacity when exporting individual OM overview', function() {
+    it('should also format capacity when exporting individual OM overview', function () {
       var capacityExport = getExportCsv(orgUnit.OFFENDER_MANAGER.name, helper.OM_OVERVIEW_RESULT, tabs.OVERVIEW).csv
       expect(capacityExport).to.include('105.00%')
     })


### PR DESCRIPTION
Formats capacity percentage from overview table to two decimal places and appends a percentage sign to the end. 