### PR TITLE
Keep links for names inside the data table blue

### DIFF
--- a/app/assets/sass/_wmt/_wmt-data-table.scss
+++ b/app/assets/sass/_wmt/_wmt-data-table.scss
@@ -58,6 +58,10 @@ table td.capacity-red {
   color: #ff0000 !important;
 }
 
+table td a:visited {
+    color: #005ea5 !important;
+}
+
 ul.sub-tier-header {
     width: 369px;
     display: block;

--- a/app/assets/sass/_wmt/_wmt-sub-nav.scss
+++ b/app/assets/sass/_wmt/_wmt-sub-nav.scss
@@ -19,6 +19,10 @@
     text-decoration: none;
   }
 
+  a:visited {
+    color:$black;
+  }
+
   .wmt-sub-nav__link.is-active {
     color: $govuk-blue;
 

--- a/app/assets/sass/_wmt/_wmt-tabs.scss
+++ b/app/assets/sass/_wmt/_wmt-tabs.scss
@@ -90,7 +90,3 @@
     display:block; 
     border-top:1px solid #ddd; 
 }
-
-a:visited {
-    color: #000;
-}

--- a/app/views/includes/organisation-overview.html
+++ b/app/views/includes/organisation-overview.html
@@ -9,7 +9,7 @@
         </tr>
         <tr>
         <th scope="row">Team</th>
-        <td class="numeric"><a href="/probation/team/{{ overviewDetails.teamId }}">{{ overviewDetails.teamName }}</a></td>
+        <td class="numeric blue-link"><a href="/probation/team/{{ overviewDetails.teamId }}">{{ overviewDetails.teamName }}</a></td>
         </tr>
         <tr>
         <th scope="row">Capacity</th>
@@ -64,7 +64,7 @@
     <tbody>
     {% for member in overviewDetails %}
       <tr >
-        <td headers="name om"><a href="/probation/{{ childOrganisationLevel }}/{{ member.linkId }}">{{ member.name }}</td>
+        <td class="blue-link" headers="name om"><a href="/probation/{{ childOrganisationLevel }}/{{ member.linkId }}">{{ member.name }}</td>
         {% if organisationLevel === 'team' %}  
           <td headers="grade om">{{ member.gradeCode }}</td>
         {% endif %}

--- a/app/views/includes/organisation-overview.html
+++ b/app/views/includes/organisation-overview.html
@@ -9,7 +9,7 @@
         </tr>
         <tr>
         <th scope="row">Team</th>
-        <td class="numeric blue-link"><a href="/probation/team/{{ overviewDetails.teamId }}">{{ overviewDetails.teamName }}</a></td>
+        <td class="numeric"><a href="/probation/team/{{ overviewDetails.teamId }}">{{ overviewDetails.teamName }}</a></td>
         </tr>
         <tr>
         <th scope="row">Capacity</th>
@@ -64,7 +64,7 @@
     <tbody>
     {% for member in overviewDetails %}
       <tr >
-        <td class="blue-link" headers="name om"><a href="/probation/{{ childOrganisationLevel }}/{{ member.linkId }}">{{ member.name }}</td>
+        <td headers="name om"><a href="/probation/{{ childOrganisationLevel }}/{{ member.linkId }}">{{ member.name }}</td>
         {% if organisationLevel === 'team' %}  
           <td headers="grade om">{{ member.gradeCode }}</td>
         {% endif %}


### PR DESCRIPTION
Links under the name column and Team Name on OM screen were turning black when visited. This change should keep them blue. 