### PR TITLE
Stop the jmeter tests flooding the DB with connections

### DIFF
--- a/app/services/data/create-court-reports-calculation-task.js
+++ b/app/services/data/create-court-reports-calculation-task.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (courtReportStagingId, workloadReportId, batchSize) {
   var newTask = {

--- a/app/services/data/get-latest-court-reports-staging-id-and-workload-report-id.js
+++ b/app/services/data/get-latest-court-reports-staging-id-and-workload-report-id.js
@@ -1,5 +1,4 @@
-const config = require('../../../knexfile').web
-const knex = require('knex')(config)
+const knex = require('../../../knex').web
 
 module.exports = function (id) {
   return knex('workload_owner')


### PR DESCRIPTION
When knex is used incorrectly, a pool is created for each connection, this
overwhelms the database server and all of the tests get an error when trying to
connect.

In order to prevent that each database connection should be created by a global
pool object.