### PR TITLE
Call caseload views with noexpand hint.

### DIFF
--- a/app/services/data/get-caseload.js
+++ b/app/services/data/get-caseload.js
@@ -1,14 +1,16 @@
 const knex = require('../../../knex').web
 const orgUnitFinder = require('../helpers/org-unit-finder')
+const ORGANISATION_UNIT = require('../../constants/organisation-unit')
 
 module.exports = function (id, type) {
   var orgUnit = orgUnitFinder('name', type)
   var table = orgUnit.caseloadView
 
-  var selectColumns = [
+  var selectList = [
     'link_id AS linkId',
-    'name',
     'grade_code AS grade',
+    'total_cases AS totalCases',
+    'location AS caseType',
     'untiered',
     'd2',
     'd1',
@@ -16,15 +18,27 @@ module.exports = function (id, type) {
     'c1',
     'b2',
     'b1',
-    'a',
-    'total_cases AS totalCases',
-    'case_type AS caseType'
+    'a'
   ]
 
-  return knex(table)
-    .where('id', id)
-    .select(selectColumns)
-    .then(function (results) {
-      return results
-    })
+  var requiresWorkloadOwnerName = (type === ORGANISATION_UNIT.TEAM.name)
+
+  if (requiresWorkloadOwnerName) {
+    selectList.push('CONCAT(forename, \' \', surname) AS name')
+  } else {
+    selectList.push('name')
+  }
+
+  var whereString = ''
+
+  if (id !== undefined && (!isNaN(parseInt(id, 10)))) {
+    whereString += ' WHERE id = ' + id
+  }
+
+  var noExpandHint = ' WITH (NOEXPAND)'
+
+  return knex.schema.raw('SELECT ' + selectList.join(', ') +
+      ' FROM ' + table +
+      noExpandHint +
+      whereString)
 }

--- a/knexfile.js
+++ b/knexfile.js
@@ -25,7 +25,8 @@ module.exports = {
       password: config.MIGRATION_APP_DATABASE_PASSWORD,
       database: config.DATABASE,
       options: {
-        encrypt: true
+        encrypt: true,
+        requestTimeout: 60000
       }
     },
     debug: false

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "gulp",
     "build": "yarn install && gulp generate-assets && gulp sync",
     "unit-test": "standard && mocha --recursive test/unit/",
-    "integration-test": "gulp assets && mocha --recursive test/integration --timeout=30000",
+    "integration-test": "gulp assets && mocha --recursive test/integration --timeout=60000",
     "test": "yarn unit-test && yarn integration-test",
     "test-e2e": "gulp --gulpfile gulpfile-e2e.js",
     "test-e2e-firefox": "wdio test/wdio.conf.sauce.firefox.js",

--- a/test/integration/services/data/test-get-caseload.js
+++ b/test/integration/services/data/test-get-caseload.js
@@ -25,7 +25,7 @@ describe('services/data/get-caseload', function () {
         expect(results[0].b2).to.eql(5)
         expect(results[0].b1).to.eql(6)
         expect(results[0].a).to.eql(7)
-        expect(results[0].totalCases).to.eql(0)
+        expect(results[0].totalCases).to.eql(28)
       })
   })
 
@@ -65,7 +65,7 @@ describe('services/data/get-caseload', function () {
         expect(results[0].b2).to.eql(10)
         expect(results[0].b1).to.eql(12)
         expect(results[0].a).to.eql(14)
-        expect(results[0].totalCases).to.eql(0)
+        expect(results[0].totalCases).to.eql(56)
       })
   })
 


### PR DESCRIPTION
Also, now the views take the total cases from the tiers table, instead of the
workload table - meaning the integration tests had to be updated.

Finally, now that all the caseload views are indexed, these indexes need to be
maintained when an insert occurs this means the timeout of requests need to be
extended.