### PR TITLE
Use the minified version of plotly

### DIFF
--- a/app/views/capacity.html
+++ b/app/views/capacity.html
@@ -185,6 +185,6 @@
     <script type="text/javascript">
         var capacityTable = {{ capacity | dump | safe }}
     </script>
-    <script src="/public/javascripts/plotly.js"></script>
+    <script src="/public/javascripts/plotly-latest.min.js"></script>
     <script src="/public/javascripts/caseload-capacity.js"></script>
 {% endblock %}

--- a/app/views/case-progress.html
+++ b/app/views/case-progress.html
@@ -49,6 +49,6 @@
         var rowTitle = {{ title | dump | safe }}
         var caseProgress = {{ caseProgressList | dump | safe }}
     </script>
-    <script src="/public/javascripts/plotly.js"></script>
+    <script src="/public/javascripts/plotly-latest.min.js"></script>
     <script src="/public/javascripts/case-progress.js"></script>
 {% endblock %}


### PR DESCRIPTION
In order to improve response times, we should use the smaller, minified version
of plotly rather than the source.