### PR TITLE
Enhancement/cosmetic changes - All headings centre aligned

### DIFF
--- a/app/assets/sass/_wmt/_wmt-data-table.scss
+++ b/app/assets/sass/_wmt/_wmt-data-table.scss
@@ -15,7 +15,7 @@ table.data-table tr th{
     border: 1px solid #d9d9d9;
 }
 
-table.data-table tr th:not(:first-child){
+table.data-table tr th{
     text-align: center;
 }
 

--- a/app/views/capacity.html
+++ b/app/views/capacity.html
@@ -111,7 +111,7 @@
     <thead>
       <tr>
         <th colspan="2" id="org">{{ childOrganisationLevelDisplayText }}</th>
-        <th colspan="8" id="breakdown">Workload breakdown</th>
+        <th colspan="9" id="breakdown">Workload breakdown</th>
       </tr>
       <tr>
         <th id="name">Name</th>
@@ -158,7 +158,7 @@
             {% if i === 0 %}
               <td rowspan="{{ member.grades.length }}" headers="name org"><a href="/probation/{{ childOrganisationLevel }}/{{ member.linkId }}">{{ member.name }}</a></td>
             {% endif %}
-          <td headers="grade org">{{ member.grades[i].grade }}</td>
+          <td class="align-centre" headers="grade org">{{ member.grades[i].grade }}</td>
           {% if member.grades[i].capacityPercentage > 110 %}
             <td class="capacity-red" headers="capacity breakdown">{{ member.grades[i].capacityPercentage | round(1) }}%</td>
           {% else %}

--- a/app/views/caseload.html
+++ b/app/views/caseload.html
@@ -67,7 +67,7 @@
             {% for member in caseType.array %}
               <tr>
                 <td headers="{{caseType.displayName}}_om {{caseType.displayName}}_name"><a href="/probation/{{ childOrganisationLevel }}/{{ member.linkId }}">{{ member.name }}</a></td>
-                <td headers="{{caseType.displayName}}_om {{caseType.displayName}}_grade">{{ member.grade }}</td>
+                <td class="align-centre" headers="{{caseType.displayName}}_om {{caseType.displayName}}_grade">{{ member.grade }}</td>
                 <td headers="{{caseType.displayName}}_tiers {{caseType.displayName}}_a">{{ member.a }}</td>
                 <td headers="{{caseType.displayName}}_tiers {{caseType.displayName}}_b1">{{ member.b1 }}</td>
                 <td headers="{{caseType.displayName}}_tiers {{caseType.displayName}}_b2">{{ member.b2 }}</td>
@@ -152,7 +152,7 @@
                 {% if i === 0 %}
                 <td rowspan="{{ member.grades.length }}" headers="{{caseType.displayName}}_om {{caseType.displayName}}_name"><a href="/probation/{{ childOrganisationLevel }}/{{ member.linkId }}">{{ member.name }}</a></td>
                 {% endif %}
-                <td headers="{{caseType.displayName}}_om {{caseType.displayName}}_grade">{{ member.grades[i].grade }}</td>            
+                <td class="align-centre" headers="{{caseType.displayName}}_om {{caseType.displayName}}_grade">{{ member.grades[i].grade }}</td>            
                 <td headers="{{caseType.displayName}}_tiers {{caseType.displayName}}_a">{{ member.grades[i].a | round(1) }}</td>
                 <td headers="{{caseType.displayName}}_tiers {{caseType.displayName}}_b1">{{ member.grades[i].b1 | round(1) }}</td>
                 <td headers="{{caseType.displayName}}_tiers {{caseType.displayName}}_b2">{{ member.grades[i].b2 | round(1) }}</td>


### PR DESCRIPTION
Asked for headings to be centred now instead of all except division / name.
Fixed issue with nested grade codes not being aligned.
Fixed issue with missing header for CMS column.