### PR TITLE
Fix/reduction end date read only

### DIFF
--- a/app/assets/javascripts/add-reduction.js
+++ b/app/assets/javascripts/add-reduction.js
@@ -1,6 +1,7 @@
 // Set current year dynamically
   var daysInMonth = [31,28,31,30,31,30,31,31,30,31,30,31]
-  var currentYear = new Date().getYear()
+  var currentYear = new Date().getFullYear()
+  console.log(new Date().getFullYear())
   document.getElementById('start-year').setAttribute('min', currentYear)
 
   var chosenReduction

--- a/app/assets/javascripts/add-reduction.js
+++ b/app/assets/javascripts/add-reduction.js
@@ -1,7 +1,6 @@
 // Set current year dynamically
   var daysInMonth = [31,28,31,30,31,30,31,31,30,31,30,31]
   var currentYear = new Date().getFullYear()
-  console.log(new Date().getFullYear())
   document.getElementById('start-year').setAttribute('min', currentYear)
 
   var chosenReduction
@@ -67,7 +66,8 @@
     var chosenReductionIndex = document.getElementById("select-box").selectedIndex
     
     if(chosenReductionIndex){
-      chosenReduction = refData[chosenReductionIndex]
+      // Dummy option in dropdown means array is offset by one
+      chosenReduction = refData[chosenReductionIndex - 1]
 
       var startDay = document.getElementById("start-day").value      
       var startMonth = document.getElementById("start-month").value


### PR DESCRIPTION
Remaining Item 15 on spreadsheet. Minimum year validation for start date of reduction now works - method getYear is no longer supported by JS. Main issue caused by selecting one index above the actual chosen reason because of a dummy value in the dropdown options. 