### PR TITLE
Fix/button over headers

### DIFF
--- a/app/assets/javascripts/case-overview.js
+++ b/app/assets/javascripts/case-overview.js
@@ -4,6 +4,7 @@ $(document).ready(function() {
         searching: false,
         info: false,
         "aaSorting": [],
+        "order": [[ 0, "asc" ]],
         columnDefs: [{
           targets: [],
           orderable: false

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -14,13 +14,10 @@ $path: "/public/images/";
   position: absolute !important;
 }
 
-a.reduction-export:visited{
+a.button:visited{
     color:white !important;
 }
 
-a.sln-export:visited{
-    color:white !important;
-}
 @mixin respond-to($media) {
   @if $media==handhelds {
     @media only screen and (max-width: 568px) {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -14,6 +14,10 @@ $path: "/public/images/";
   position: absolute !important;
 }
 
+
+table.export-buttons td a:visited {
+    color:white !important;
+}
 @mixin respond-to($media) {
   @if $media==handhelds {
     @media only screen and (max-width: 568px) {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -14,8 +14,11 @@ $path: "/public/images/";
   position: absolute !important;
 }
 
+a.reduction-export:visited{
+    color:white !important;
+}
 
-table.export-buttons td a:visited {
+a.sln-export:visited{
     color:white !important;
 }
 @mixin respond-to($media) {

--- a/app/views/includes/export-reductions.html
+++ b/app/views/includes/export-reductions.html
@@ -1,5 +1,0 @@
-{% if ((authorisation===false) or (userRole==='Data Admin') or (userRole==='Manager') or (userRole==='System Admin')) %}
-<div class="reduction-button">
-    <a href="/probation/{{ organisationLevel }}/{{ linkId }}/{{ screen }}/reductions-csv" class="button reduction-export" style="float: right; margin-right: 5px; margin-bottom: 10px">Export Reductions</a>
-</div>
-{% endif %}

--- a/app/views/includes/export-reductions.html
+++ b/app/views/includes/export-reductions.html
@@ -1,3 +1,5 @@
 {% if ((authorisation===false) or (userRole==='Data Admin') or (userRole==='Manager') or (userRole==='System Admin')) %}
+<div class="reduction-button">
     <a href="/probation/{{ organisationLevel }}/{{ linkId }}/{{ screen }}/reductions-csv" class="button reduction-export" style="float: right; margin-right: 5px; margin-bottom: 10px">Export Reductions</a>
+</div>
 {% endif %}

--- a/app/views/includes/organisation-overview.html
+++ b/app/views/includes/organisation-overview.html
@@ -2,9 +2,7 @@
     <tr>
         <td>
         {% ifAsync ((organisationLevel === 'region') or (organisationLevel === 'ldu') or (organisationLevel === 'team')) %}
-        {% if ((authorisation===false) or (userRole==='Data Admin') or (userRole==='Manager') or (userRole==='System Admin')) %}
         <a href="/probation/{{ organisationLevel }}/{{ linkId }}/{{ screen }}/reductions-csv" class="button reduction-export" style="float: right; margin-left:10px; margin-bottom: 10px">Export Reductions</a>
-        {% endif %}
         {% endif %}
         <a href="/probation/{{ organisationLevel }}/{{ linkId }}/{{ screen }}/caseload-csv" class="button sln-export" style="float: right; margin-bottom: 10px; ">Export Caseload</a>
         </td>

--- a/app/views/includes/organisation-overview.html
+++ b/app/views/includes/organisation-overview.html
@@ -1,3 +1,16 @@
+<table>
+    <tr>
+        <td>
+        {% ifAsync ((organisationLevel === 'region') or (organisationLevel === 'ldu') or (organisationLevel === 'team')) %}
+        {% if ((authorisation===false) or (userRole==='Data Admin') or (userRole==='Manager') or (userRole==='System Admin')) %}
+        <a href="/probation/{{ organisationLevel }}/{{ linkId }}/{{ screen }}/reductions-csv" class="button reduction-export" style="float: right; margin-left:10px; margin-bottom: 10px">Export Reductions</a>
+        {% endif %}
+        {% endif %}
+        <a href="/probation/{{ organisationLevel }}/{{ linkId }}/{{ screen }}/caseload-csv" class="button sln-export" style="float: right; margin-bottom: 10px; ">Export Caseload</a>
+        </td>
+    </tr>
+</table>
+
 {% if organisationLevel === "offender-manager" %}
 <div class="grid-row">
     <div class="column-two-thirds">
@@ -36,6 +49,7 @@
     </div>
 </div>
 {% else %}
+
 <table id="example" class="js-data-table data-table dataTable" cellspacing="0" width="100%" role="grid" aria-describedby="example_info" style="width: 100%;">
     <thead>
         <tr>

--- a/app/views/includes/organisation-overview.html
+++ b/app/views/includes/organisation-overview.html
@@ -1,4 +1,4 @@
-<table class="export-buttons">
+<table>
     <tr>
         <td>
         {% ifAsync ((organisationLevel === 'region') or (organisationLevel === 'ldu') or (organisationLevel === 'team')) %}

--- a/app/views/includes/organisation-overview.html
+++ b/app/views/includes/organisation-overview.html
@@ -1,4 +1,4 @@
-<table>
+<table class="export-buttons">
     <tr>
         <td>
         {% ifAsync ((organisationLevel === 'region') or (organisationLevel === 'ldu') or (organisationLevel === 'team')) %}

--- a/app/views/overview.html
+++ b/app/views/overview.html
@@ -12,12 +12,6 @@
 
 {% include "includes/sub-nav.html" %}
 
-{% include "includes/export-caseload.html" %}
-
-{% ifAsync ((organisationLevel === 'region') or (organisationLevel === 'ldu') or (organisationLevel === 'team')) %}
-    {% include "includes/export-reductions.html" %}
-{% endif %}
-
 {% include "includes/organisation-overview.html"%}
 
 </main>


### PR DESCRIPTION
Fixed the export caseload and export reduction button, so that they don't appear on top of the tables in older versions of Firefox.