### PR TITLE
added in a closing tag for form so that the footer could go full screen

### DIFF
--- a/app/views/capacity.html
+++ b/app/views/capacity.html
@@ -75,8 +75,8 @@
     </div>
 
     <input id="caseload-filter-submit" type="submit" value="Filter" class="button">
-
-<form>
+    
+</form>
 
 <table class="non-javascript">
     <thead>
@@ -254,6 +254,7 @@
         </tr>
         {% endfor %}
       {% endfor %}
+    </tbody>
     {% endif %}
   </table>
 {% endif %}


### PR DESCRIPTION
Footer on the capacity page wasn't showing up full screen on the older version of Firefox, added in some closing tags to fix this