### PR TITLE
Fix error in reduction service test dates

### DIFF
--- a/test/unit/services/test-get-reduction-export.js
+++ b/test/unit/services/test-get-reduction-export.js
@@ -7,8 +7,8 @@ const proxyquire = require('proxyquire')
 const breadcrumbHelper = require('../../helpers/breadcrumb-helper')
 const orgUnitConstant = require('../../../app/constants/organisation-unit.js')
 
-var activeStartDate = moment('12-25-2017').toDate() // 2017-12-25T00:00:00.000Z
-var activeEndDate = moment('12-25-2018').toDate() // 2018-12-25T00:00:00.000Z
+var activeStartDate = moment('25-12-2017', 'DD-MM-YYYY').toDate() // 2017-12-25T00:00:00.000Z
+var activeEndDate = moment('25-12-2018', 'DD-MM-YYYY').toDate() // 2018-12-25T00:00:00.000Z
 
 var breadcrumbs = breadcrumbHelper.TEAM_BREADCRUMBS
 

--- a/test/unit/services/test-reduction-service.js
+++ b/test/unit/services/test-reduction-service.js
@@ -39,8 +39,8 @@ var reductionReason = {
 }
 
 var reduction = new Reduction('1', '10',
-  [activeStartDate.getDate(), activeStartDate.getMonth(), activeStartDate.getFullYear()],
-  [activeEndDate.getDate(), activeEndDate.getMonth(), activeEndDate.getFullYear()], 'active note', reductionReason)
+  [activeStartDate.getDate(), activeStartDate.getMonth() + 1, activeStartDate.getFullYear()],
+  [activeEndDate.getDate(), activeEndDate.getMonth() + 1, activeEndDate.getFullYear()], 'active note', reductionReason)
 
 var referenceData = [
   {


### PR DESCRIPTION
Moment dates supplied should include the format string parameter eg. moment('31-03-1995', 'DD-MM-YYYY') to avoid deprecation warning.
Fixes error by adding one onto the month in tests when using moment as the application takes user input and therefore subtracts one from the user input as moments months are zero indexed. 