### PR TITLE
Fix/infinity individual capacity

### DIFF
--- a/app/services/get-overview.js
+++ b/app/services/get-overview.js
@@ -55,7 +55,7 @@ var calculateValues = function (results, isCSV) {
     }
   } else {
     var capacityPercentage = 0
-    if(results.availablePoints > 0) {
+    if (results.availablePoints > 0) {
       capacityPercentage = (results.totalPoints / results.availablePoints) * 100
     }
     totalsToReturn = Object.assign({}, results, {capacity: capacityPercentage})

--- a/app/services/get-overview.js
+++ b/app/services/get-overview.js
@@ -54,7 +54,10 @@ var calculateValues = function (results, isCSV) {
       totalsToReturn.push(totals)
     }
   } else {
-    var capacityPercentage = (results.totalPoints / results.availablePoints) * 100
+    var capacityPercentage = 0
+    if(results.availablePoints > 0) {
+      capacityPercentage = (results.totalPoints / results.availablePoints) * 100
+    }
     totalsToReturn = Object.assign({}, results, {capacity: capacityPercentage})
   }
   return totalsToReturn


### PR DESCRIPTION
Divide by zero error was occurring on individual overviews for offender managers with zero available points resulting in Infinity%. Checks if available points = 0, then set capacity to zero and do not do capacity calculation. 