### PR TITLE
Fix T2A Workload points other tab results

### DIFF
--- a/app/services/workload-points-service.js
+++ b/app/services/workload-points-service.js
@@ -21,6 +21,9 @@ module.exports.getWorkloadPoints = function (isT2A) {
       var formattedUpdateDate = dateFormatter.formatDate(workloadPoints.effectiveFrom, 'DD/MM/YYYY HH:mm')
       workloadPoints.effectiveFrom = formattedUpdateDate
       userId = workloadPoints.updatedByUserId
+    } else {
+      workloadPoints = {}
+      workloadPoints.isT2A = isT2A
     }
     return userRoleService.getUserById(userId)
     .then(function (user) {

--- a/app/views/workload-points.html
+++ b/app/views/workload-points.html
@@ -306,8 +306,8 @@
       </div>
 
       <div id="other">
-          <p><span class="bold">Delivery Report Workload Points</span></p>
           {% if not isT2A %}
+          <p><span class="bold">Delivery Report Workload Points</span></p>
           <div class="grid-row">
             <div class="column-two-thirds">
               <table>


### PR DESCRIPTION
An empty result from the workload points data service was causing T2A to be set to undefined / false even when the user was on the T2A page. Workload points T2A Other tab should only show the Weighting header with three rows for Overdue terminations, Active warrants and UPW outstanding. 