### PR TITLE
Add a solid black border to prevent gridlines disappearing

### DIFF
--- a/app/assets/sass/_wmt/_wmt-data-table.scss
+++ b/app/assets/sass/_wmt/_wmt-data-table.scss
@@ -10,13 +10,13 @@ table.data-table {
     max-width: 1024px!important;
 }
 
-table.data-table tr th{
+table.data-table tr th {
     padding: 0 10px;
-    border: 1px solid #d9d9d9;
+    text-align: center;
 }
 
-table.data-table tr th{
-    text-align: center;
+table.data-table tr, table.data-table th, table.data-table td {
+    border: 2px solid #000000;
 }
 
 table tr.headers th{
@@ -25,8 +25,6 @@ table tr.headers th{
 
 table.data-table tr td{
     padding:5px 10px 5px 10px;
-    border-left: 1px solid #d9d9d9;
-    border: 1px solid #d9d9d9!important;
 }
 
 table.data-table th, table.data-table td {


### PR DESCRIPTION
Citrix compresses images when connecting to the users which can cause the border to look invisible - previously we had a 1px, light grey border. 