### PR TITLE
Data tables have 2px solid black borders

### DIFF
--- a/app/assets/sass/_wmt/_wmt-data-table.scss
+++ b/app/assets/sass/_wmt/_wmt-data-table.scss
@@ -10,13 +10,13 @@ table.data-table {
     max-width: 1024px!important;
 }
 
-table.data-table tr th{
+table.data-table tr th {
     padding: 0 10px;
-    border: 1px solid #d9d9d9;
+    text-align: center;
 }
 
-table.data-table tr th{
-    text-align: center;
+table.data-table tr, table.data-table th, table.data-table td {
+    border: 2px solid #000000;
 }
 
 table tr.headers th{
@@ -25,8 +25,6 @@ table tr.headers th{
 
 table.data-table tr td{
     padding:5px 10px 5px 10px;
-    border-left: 1px solid #d9d9d9;
-    border: 1px solid #d9d9d9!important;
 }
 
 table.data-table th, table.data-table td {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "selenium-standalone": "6.11.0",
     "sinon": "^1.17.5",
     "sinon-bluebird": "^3.1.0",
-    "standard": "^10.0.2",
+    "standard": "^10.0.3",
     "supertest": "3.0.x",
     "wdio-mocha-framework": "^0.5.10",
     "wdio-sauce-service": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4328,7 +4328,7 @@ standard-engine@~7.0.0:
     minimist "^1.1.0"
     pkg-conf "^2.0.0"
 
-standard@^10.0.2:
+standard@^10.0.3:
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/standard/-/standard-10.0.3.tgz#7869bcbf422bdeeaab689a1ffb1fea9677dd50ea"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3057,6 +3057,10 @@ moment@2.x.x, moment@^2.10.6, moment@^2.18.1, moment@^2.9.0:
   version "2.19.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.1.tgz#56da1a2d1cbf01d38b7e1afc31c10bcfa1929167"
 
+moment@^2.19.2:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.4.tgz#17e5e2c6ead8819c8ecfad83a0acccb312e94682"
+
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -4082,9 +4086,9 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
-selenium-standalone@6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/selenium-standalone/-/selenium-standalone-6.5.0.tgz#5ecaffdcb15799fe69954e6143791a38bf88dfd1"
+selenium-standalone@6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/selenium-standalone/-/selenium-standalone-6.11.0.tgz#eb21ff65f3b2ece75061b35d4f9e7572ac0280c2"
   dependencies:
     async "^2.1.4"
     commander "^2.9.0"
@@ -4882,12 +4886,12 @@ window-size@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
 
-wmt-probation-rules@ministryofjustice/wmt-probation-rules.git#v0.7.0:
-  version "0.7.0"
-  resolved "https://codeload.github.com/ministryofjustice/wmt-probation-rules/tar.gz/44ce22f4a2d440e8e5043aa391924c34a2ad8bd1"
+wmt-probation-rules@ministryofjustice/wmt-probation-rules.git#v0.8.1:
+  version "0.8.1"
+  resolved "https://codeload.github.com/ministryofjustice/wmt-probation-rules/tar.gz/ba7cb8af0435056985332ace2f158a848233f486"
   dependencies:
     lodash "^4.17.4"
-    moment "^2.18.1"
+    moment "^2.19.2"
 
 wordwrap@~0.0.2:
   version "0.0.3"


### PR DESCRIPTION
Citrix compresses images when connecting to user which can cause borders to look invisible. Fix this issue by replacing our 1px light grey border with a 2px solid black border. 