### PR TITLE
Prevent fieldset validator from testing date past the set date limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,6 @@
     "underscore": "^1.8.3",
     "util": "^0.10.3",
     "validator": "^8.2.0",
-    "wmt-probation-rules": "ministryofjustice/wmt-probation-rules.git#v0.8.1"
+    "wmt-probation-rules": "ministryofjustice/wmt-probation-rules.git#v0.8.6"
   }
 }

--- a/test/unit/services/validators/test-fieldset-validator.js
+++ b/test/unit/services/validators/test-fieldset-validator.js
@@ -184,7 +184,7 @@ describe('services/validators/fieldset-validator', function () {
     })
 
     it('should return false if date is within the valid range', function () {
-      var validDate = dateFormatter.now().add(81, 'years').toDate()
+      var validDate = dateFormatter.now().add(50, 'years').toDate()
       var validDateArray = [validDate.getDate(), validDate.getMonth() + 1, validDate.getFullYear()]
       FieldsetValidator(validDateArray, FIELD_NAME, errorHandler)
           .isValidDate()


### PR DESCRIPTION
Fieldset validator has a date limit of 2099 - the test was originally adding on 81 years to the current date which put the test out of the valid range.