### PR TITLE
WFP-1202 move breadcrumbs outside main content

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,6 @@ Run tests using the following commands:
 
 ```
 docker-compose up -d
-npm run start
+npm start
 npm run test-e2e # Chrome
 ```

--- a/app/views/add-reduction-reason.njk
+++ b/app/views/add-reduction-reason.njk
@@ -1,8 +1,7 @@
 {% extends "includes/layout.njk" %} 
 
 {% block content %}
-  {% include "includes/breadcrumbs.njk" %}
-
+  
   {% include "includes/validation-error-messages.njk" %}
 
   {% include "includes/title-subtitle.njk"%}

--- a/app/views/add-reduction.njk
+++ b/app/views/add-reduction.njk
@@ -1,8 +1,7 @@
 {% extends "includes/layout.njk" %} 
 
 {% block content %}
-  {% include "includes/breadcrumbs.njk" %}
-
+  
   {% if reduction %}
     {% set headerText='Reduction' %}
     {% set reductionText='Showing reduction for ' %}

--- a/app/views/admin.njk
+++ b/app/views/admin.njk
@@ -1,7 +1,6 @@
 {% extends "includes/layout.njk" %}
 
-{% block content %}  {% include "includes/breadcrumbs.njk" %}
-   
+{% block content %}     
   {% include "includes/title-subtitle.njk" %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">

--- a/app/views/archive-options.njk
+++ b/app/views/archive-options.njk
@@ -1,7 +1,6 @@
 {% extends "includes/layout.njk" %}
 
-{% block content %}  {% include "includes/breadcrumbs.njk" %}
-   
+{% block content %}     
   {% include "includes/title-subtitle.njk" %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">

--- a/app/views/averaged-caseload-data.njk
+++ b/app/views/averaged-caseload-data.njk
@@ -1,8 +1,6 @@
 {% extends "includes/layout.njk" %} 
 
 {% block content %}
-
-{% include "includes/breadcrumbs.njk" %}
  
 {% include "includes/title-subtitle.njk" %}
 

--- a/app/views/capacity.njk
+++ b/app/views/capacity.njk
@@ -2,8 +2,6 @@
 
 {% block content %}
 
-{% include "includes/breadcrumbs.njk" %}
-
 {% include "includes/title-subtitle.njk" %}
 {% include "includes/sub-nav.njk" %}
 

--- a/app/views/case-progress.njk
+++ b/app/views/case-progress.njk
@@ -2,8 +2,6 @@
 
 {% block content %}
 
-{% include "includes/breadcrumbs.njk" %}
-
 {% include "includes/validation-error-messages.njk" %}
 
 {% include "includes/title-subtitle.njk" %}

--- a/app/views/caseload.njk
+++ b/app/views/caseload.njk
@@ -3,8 +3,6 @@
 
 {% block content %}
 
-{% include "includes/breadcrumbs.njk" %}
-
 {% include "includes/validation-error-messages.njk" %}
 
 {% include "includes/title-subtitle.njk" %}

--- a/app/views/contracted-hours.njk
+++ b/app/views/contracted-hours.njk
@@ -2,8 +2,6 @@
 
 {% block content %}
 
-{% include "includes/breadcrumbs.njk" %}
-
 {% include "includes/validation-error-messages.njk" %}
 
 {% include "includes/title-subtitle.njk" %}

--- a/app/views/court-reports-overview.njk
+++ b/app/views/court-reports-overview.njk
@@ -2,8 +2,6 @@
 
 {% block content %}
 
-{% include "includes/breadcrumbs.njk" %}
-
 {% include "includes/validation-error-messages.njk" %}
 
 {% include "includes/title-subtitle.njk" %}

--- a/app/views/daily-caseload-data.njk
+++ b/app/views/daily-caseload-data.njk
@@ -1,8 +1,6 @@
 {% extends "includes/layout.njk" %} 
 
 {% block content %}
-
-{% include "includes/breadcrumbs.njk" %}
  
 {% include "includes/title-subtitle.njk" %}
 

--- a/app/views/dashboard.njk
+++ b/app/views/dashboard.njk
@@ -2,8 +2,7 @@
 
 {% block content %}
 
-    {% include "includes/breadcrumbs.njk" %}
-
+    
     {% include "includes/validation-error-messages.njk" %}
 
     {% include "includes/title-subtitle.njk" %}

--- a/app/views/edit-reduction-reason.njk
+++ b/app/views/edit-reduction-reason.njk
@@ -1,8 +1,7 @@
 {% extends "includes/layout.njk" %} 
 
 {% block content %}
-  {% include "includes/breadcrumbs.njk" %}
-
+  
   {% include "includes/validation-error-messages.njk" %}
 
   {% include "includes/title-subtitle.njk"%}

--- a/app/views/export.njk
+++ b/app/views/export.njk
@@ -2,8 +2,7 @@
 
 {% block content %}
 
-    {% include "includes/breadcrumbs.njk" %}
-
+    
     {% include "includes/validation-error-messages.njk" %}
 
     {% include "includes/title-subtitle.njk" %}

--- a/app/views/includes/layout.njk
+++ b/app/views/includes/layout.njk
@@ -78,6 +78,10 @@
     {% include "includes/scripts.njk" %}
 {% endblock %}
 
+{% block beforeContent %}
+    {% include "includes/breadcrumbs.njk" %}
+{% endblock %}  
+
 {% block footer %}
     {% include "includes/footer.njk" %}
 {% endblock %}

--- a/app/views/individual-overview.njk
+++ b/app/views/individual-overview.njk
@@ -2,8 +2,6 @@
 
 {% block content %}
 
-{% include "includes/breadcrumbs.njk" %}
-
 {% include "includes/title-subtitle.njk" %}
 
 {% include "includes/sub-nav.njk" %}

--- a/app/views/manage-reduction-reasons.njk
+++ b/app/views/manage-reduction-reasons.njk
@@ -1,8 +1,7 @@
 {% extends "includes/layout.njk" %} 
 
 {% block content %}
-    {% include "includes/breadcrumbs.njk" %}
-    
+        
     {% include "includes/validation-error-messages.njk" %} 
     
     {% include "includes/title-subtitle.njk"%}

--- a/app/views/omic-export.njk
+++ b/app/views/omic-export.njk
@@ -2,8 +2,7 @@
 
 {% block content %}
 
-    {% include "includes/breadcrumbs.njk" %}
-
+    
     {% include "includes/validation-error-messages.njk" %}
 
     {% include "includes/title-subtitle.njk" %}

--- a/app/views/omic-overview.njk
+++ b/app/views/omic-overview.njk
@@ -2,8 +2,6 @@
 
 {% block content %}
 
-{% include "includes/breadcrumbs.njk" %}
-
 {% include "includes/validation-error-messages.njk" %}
 
 {% include "includes/title-subtitle.njk" %}

--- a/app/views/overview.njk
+++ b/app/views/overview.njk
@@ -2,8 +2,6 @@
 
 {% block content %}
 
-{% include "includes/breadcrumbs.njk" %}
-
 {% include "includes/validation-error-messages.njk" %}
 
 {% include "includes/title-subtitle.njk" %}

--- a/app/views/reduction-archive-data.njk
+++ b/app/views/reduction-archive-data.njk
@@ -1,8 +1,6 @@
 {% extends "includes/layout.njk" %} 
 
 {% block content %}
-
-{% include "includes/breadcrumbs.njk" %}
  
 {% include "includes/title-subtitle.njk" %}
 

--- a/app/views/reductions.njk
+++ b/app/views/reductions.njk
@@ -1,8 +1,7 @@
 {% extends "includes/layout.njk" %} 
 
 {% block content %}
-    {% include "includes/breadcrumbs.njk" %}
-    
+        
     {% include "includes/validation-error-messages.njk" %} 
     
     {% include "includes/title-subtitle.njk"%}

--- a/app/views/search-for-officer.njk
+++ b/app/views/search-for-officer.njk
@@ -1,8 +1,7 @@
 {% extends "includes/layout.njk" %} 
 
 {% block content %}
-  {% include "includes/breadcrumbs.njk" %}
-  <header class="govuk-heading-xl officerSearchHeader">Search for an Offender Manager</header>
+    <header class="govuk-heading-xl officerSearchHeader">Search for an Offender Manager</header>
     {% include "includes/validation-error-messages.njk" %}
    <form method="POST">
     <div class="govuk-form-group">

--- a/app/views/user-rights.njk
+++ b/app/views/user-rights.njk
@@ -1,8 +1,7 @@
 {% extends "includes/layout.njk" %}
 
 
-{% block content %}  {% include "includes/breadcrumbs.njk" %}
-
+{% block content %}  
   {% include "includes/title-subtitle.njk" %}
 
   {% include "includes/validation-error-messages.njk" %}

--- a/app/views/user.njk
+++ b/app/views/user.njk
@@ -1,7 +1,6 @@
 {% extends "includes/layout.njk" %}
 
-{% block content %}    {% include "includes/breadcrumbs.njk" %}
-    
+{% block content %}        
     {% include "includes/validation-error-messages.njk" %}
     
     {% include "includes/title-subtitle.njk" %}

--- a/app/views/workload-points.njk
+++ b/app/views/workload-points.njk
@@ -1,8 +1,7 @@
 {% extends "includes/layout.njk" %}
 
 {% block content %}
-
-{% include "includes/breadcrumbs.njk" %}  
+  
 
 {% include "includes/validation-error-messages.njk" %}
 


### PR DESCRIPTION
This has the effect of moving the breadcrumbs up to just below the main navigation (Allocations, Offender Management, OMIC etc)
this makes WMT look more like Allocations