### PR TITLE
WFP-1195: Improve accessibility of red text

### DIFF
--- a/app/assets/sass/_wmt/_wmt-data-table.scss
+++ b/app/assets/sass/_wmt/_wmt-data-table.scss
@@ -103,10 +103,6 @@ table.data-table tr.data-sub-header td:nth-child(7) {
     font-weight: bold;
 }
 
-table td.capacity-red {
-    color: #942514 !important;
-}
-
 table td a:visited {
     color: #005ea5 !important;
 }

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -48,6 +48,11 @@ tr.shown td.details-control {
   background: url('../images/details_close.png') no-repeat center center;
 }
 
+.capacity-red {
+  color: #942514 !important;
+  font-weight: bold;
+}
+
 .width800 {
   width: 800px;
 }

--- a/app/views/capacity.njk
+++ b/app/views/capacity.njk
@@ -174,6 +174,7 @@
 {% if organisationLevel !== 'offender-manager' %}
   <h3 class="govuk-heading-m">Capacity breakdown</h3>
 
+  <p class="govuk-body-s"><span class="capacity-red">Red</span> numbers are shown when capacity is over 110%</p>
   <table id="capacity-breakdown" class="govuk-table data-table dataTable">
     <thead>
       <tr>
@@ -223,7 +224,7 @@
           <td headers="capacityName org"><a class="govuk-link" href="/{{ workloadType }}/offender-manager/{{ member.linkId }}">{{ member.name }}</a></td>
           <td headers="capacityGrade org">{{ member.grade }}</td>
           {% if member.capacityPercentage > 110 %}
-            <td class="capacity-red" headers="capacity breakdown">{{ member.capacityPercentage | round(1) }}%</td>
+            <td class="capacity-red" headers="capacity breakdown">{{ member.capacityPercentage | round(1) }}%<span class="govuk-visually-hidden">. This is over 110% capacity</span></td>
           {% else %}
             <td headers="capacity breakdown">{{ member.capacityPercentage | round(1) }}%</td>
           {% endif %}
@@ -254,7 +255,7 @@
             {% endif %}
           <td class="align-centre" headers="grade org">{{ member.grades[i].grade }}</td>
           {% if member.grades[i].capacityPercentage > 110 %}
-            <td class="capacity-red" headers="capacity breakdown">{{ member.grades[i].capacityPercentage | round(1) }}%</td>
+            <td class="capacity-red" headers="capacity breakdown">{{ member.grades[i].capacityPercentage | round(1) }}%<span class="govuk-visually-hidden">. This is over 110% capacity</span></td>
           {% else %}
             <td headers="capacity breakdown">{{ member.grades[i].capacityPercentage | round(1) }}%</td>
           {% endif %}
@@ -301,7 +302,7 @@
             {% endif %}
           <td class="align-centre" headers="capacityGrade org">{{ member.grades[i].grade }}</td>
           {% if member.grades[i].capacityPercentage > 110 %}
-            <td class="capacity-red" headers="capacity breakdown">{{ member.grades[i].capacityPercentage | round(1) }}%</td>
+            <td class="capacity-red" headers="capacity breakdown">{{ member.grades[i].capacityPercentage | round(1) }}%<span class="govuk-visually-hidden">. This is over 110% capacity</span></td>
           {% else %}
             <td headers="capacity breakdown">{{ member.grades[i].capacityPercentage | round(1) }}%</td>
           {% endif %}

--- a/app/views/includes/organisation-overview.njk
+++ b/app/views/includes/organisation-overview.njk
@@ -1,5 +1,6 @@
 
-        
+    <p class="govuk-body-s"><span class="capacity-red">Red</span> numbers are shown when capacity is over 110%</p>
+
     <table id="example" class="govuk-table js-data-table data-table dataTable width100Percent" cellspacing="0" width="100%"  aria-describedby="example_info">
         <thead>
             <tr>
@@ -35,14 +36,14 @@
               <td headers="grade om">{{ member.gradeCode }}</td>
             {% endif %}
             {% if member.capacityPercentage > 110 %}
-              <td class="capacity-red" headers="current cap">{{ member.capacityPercentage | round(1) }}%</td>
+              <td class="capacity-red" headers="current cap">{{ member.capacityPercentage | round(1) }}%<span class="govuk-visually-hidden">. This is over 110% capacity</span></td>
             {% else %}
               <td headers="current cap">{{ member.capacityPercentage | round(1) }}%</td>
             {% endif %}
             <td headers="points cap">{{ member.availablePoints }}</td>
             <td headers="totalPoints cap">{{ member.totalPoints }}</td>
             {% if member.capacityPercentage > 110 %}
-              <td class="capacity-red" headers="remaining cap">{{ member.remainingPoints }}</td>
+              <td class="capacity-red" headers="remaining cap">{{ member.remainingPoints }}<span class="govuk-visually-hidden">. This is over 110% capacity</span></td>
             {% else %}
               <td headers="remaining cap">{{ member.remainingPoints}}</td>
             {% endif %}

--- a/app/views/individual-overview.njk
+++ b/app/views/individual-overview.njk
@@ -8,6 +8,7 @@
 
 <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body-s"><span class="capacity-red">Red</span> numbers are shown when capacity is over 110%</p>
             <table class="govuk-table override-gov-uk-table" id="offender-manager-overview-table">
                 <tbody>
                     <tr>
@@ -20,7 +21,11 @@
                     </tr>
                     <tr>
                         <th class="bold" scope="row">Capacity</th>
-                        <td class="sln-capacity numeric {% if overviewDetails.capacity > 110 %} capacity-red {% endif %}"> {{ overviewDetails.capacity | round }}%</td>
+                        {% if overviewDetails.capacity > 110 %}
+                            <td class="sln-capacity numeric capacity-red"> {{ overviewDetails.capacity | round }}%<span class="govuk-visually-hidden">. This is over 110% capacity</span></td>
+                        {% else %}
+                            <td class="sln-capacity numeric"> {{ overviewDetails.capacity | round }}%</td>
+                        {% endif %}
                     </tr>
                     <tr>
                         <th class="bold" scope="row">Cases</th>

--- a/test/e2e/view-overview-om.js
+++ b/test/e2e/view-overview-om.js
@@ -30,7 +30,8 @@ describe('Offender Manager', function () {
 
       let capacity = await $('.sln-capacity')
       capacity = await capacity.getText()
-      expect(capacity).to.equal(`${workloadOwnerCapacity}%`)
+      const capacityPercent = capacity.substring(0, capacity. indexOf('%'))
+      expect(capacityPercent).to.equal(`${workloadOwnerCapacity}`)
     })
 
     after(function () {

--- a/test/e2e/view-overview-om.js
+++ b/test/e2e/view-overview-om.js
@@ -30,7 +30,7 @@ describe('Offender Manager', function () {
 
       let capacity = await $('.sln-capacity')
       capacity = await capacity.getText()
-      const capacityPercent = capacity.substring(0, capacity, indexOf('%'))
+      const capacityPercent = capacity.substring(0, capacity.indexOf('%'))
       expect(capacityPercent).to.equal(`${workloadOwnerCapacity}`)
     })
 

--- a/test/e2e/view-overview-om.js
+++ b/test/e2e/view-overview-om.js
@@ -30,7 +30,7 @@ describe('Offender Manager', function () {
 
       let capacity = await $('.sln-capacity')
       capacity = await capacity.getText()
-      const capacityPercent = capacity.substring(0, capacity. indexOf('%'))
+      const capacityPercent = capacity.substring(0, capacity, indexOf('%'))
       expect(capacityPercent).to.equal(`${workloadOwnerCapacity}`)
     })
 


### PR DESCRIPTION
Had to do 3 things:

 - Add text above every table that might have red text, which explains what the red text means 
 - Made the red text bold
 - Added screen-reader only text for each cell that has red text