### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.3.3
+  hmpps: ministryofjustice/hmpps@7
   slack: circleci/slack@4.12.5
   browser-tools: circleci/browser-tools@1.4.3
 
@@ -48,7 +48,12 @@ executors:
           - DATABASE_PASSWORD=<< pipeline.parameters.database_password >>
           - SPRING_PROFILES_ACTIVE=dev,docker
           - HMPPS_SQS_LOCALSTACK_URL=http://localhost:4566
-        entrypoint: ["/bin/sh", "-c" , "sleep 10 && java -javaagent:/app/agent.jar -jar /app/app.jar"]
+        entrypoint:
+          [
+            "/bin/sh",
+            "-c",
+            "sleep 10 && java -javaagent:/app/agent.jar -jar /app/app.jar"
+          ]
       - image: localstack/localstack:2.0.2
         environment:
           - SERVICES=s3,sqs,sns
@@ -138,7 +143,7 @@ jobs:
           name: unit tests
           command: npm run test
       - when:
-          condition: 
+          condition:
             equal: [ main, << pipeline.git.branch >> ]
           steps:
             - slack/notify:
@@ -164,8 +169,8 @@ jobs:
           command: test/integration/resources/setup-s3.sh test/integration/resources
       - hmpps/wait_till_ready_postgres
       - run:
-         name: Run integration tests
-         command: npm run integration-test
+          name: Run integration tests
+          command: npm run integration-test
       - store_test_results:
           path: test_results
       - store_artifacts:
@@ -339,4 +344,3 @@ workflows:
           context:
             - veracode-credentials
             - hmpps-common-vars
- 

--- a/helm_deploy/wmt-web/Chart.yaml
+++ b/helm_deploy/wmt-web/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.2.0
 
 dependencies:
   - name: generic-service
-    version: 2.6.3
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.2

--- a/helm_deploy/wmt-web/values.yaml
+++ b/helm_deploy/wmt-web/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: wmt-web
   replicaCount: 2
@@ -7,7 +6,7 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/wmt-web
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 3000
 
   ingress:
@@ -16,7 +15,7 @@ generic-service:
     modsecurity_github_team: "manage-a-workforce"
     v1_2_enabled: true
     v0_47_enabled: false
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: workload-measurement-cert
     path: /
     contextColour: green
@@ -67,25 +66,10 @@ generic-service:
       AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    ark-internet-1: "194.33.192.0/25"
-    ark-internet-2: "194.33.196.0/25"
-    global-protect: "35.176.93.186/32"
-    quantum1: "62.25.109.197/32"
-    quantum2: "212.137.36.230/32"
-    quantum3: "195.92.38.16/28"
-    moj-official-tgw-prod: "51.149.250.0/24"
-    moj-official-tgw-preprod: "51.149.251.0/24"
-    moj-official-ark-c-expo-e: "51.149.249.0/29"
-    moj-official-ark-c-vodafone: "194.33.248.0/29"
-    moj-official-ark-f-vodafone: "194.33.249.0/29"
-    moj-official-ark-f-expo-e: "51.149.249.32/29"
-    
+    groups:
+      - internal
+      - prisons
+
 generic-prometheus-alerts:
   targetApplication: wmt-web
   alertSeverity: hmpps-tier


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/wmt-web/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal,prisons`
- The size of the allowlist defined in this file will change: `18 => 0 (18 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- petty-france-wifi
  

- ark-nps-hmcts-ttp1
  

- ark-nps-hmcts-ttp3
  

- ark-nps-hmcts-ttp5
  

- mojo-azure-landing-zone-public-egress-1
  

- mojo-azure-landing-zone-public-egress-2
  

- mojo-azure-landing-zone-public-egress-3
  

- mojo-azure-landing-zone-public-egress-4
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  

- quantum
  

- quantum_alt
  

- quantum3
  
